### PR TITLE
Descriptor refactor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(xania_lib STATIC
         update.cpp
         wiznet.cpp
         xania.cpp
-        DescriptorData.cpp DescriptorData.hpp
+        Descriptor.cpp Descriptor.hpp
         Wrapper.cpp
         string_utils.cpp string_utils.hpp)
 target_link_libraries(xania_lib crypt chat)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(xania_lib STATIC
         update.cpp
         wiznet.cpp
         xania.cpp
+        DescriptorData.cpp DescriptorData.hpp
         Wrapper.cpp
         string_utils.cpp string_utils.hpp)
 target_link_libraries(xania_lib crypt chat)

--- a/src/Descriptor.cpp
+++ b/src/Descriptor.cpp
@@ -1,4 +1,7 @@
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
+
+#include "comm.hpp"
+#include "string_utils.hpp"
 
 // Up to 5 characters
 const char *short_name_of(DescriptorState state) {
@@ -65,10 +68,46 @@ Descriptor::~Descriptor() {
     /*    free_string(dclose->showstr_head); */
 }
 
-std::optional<std::string> Descriptor::pop_pending() {
+std::optional<std::string> Descriptor::pop_raw() {
     if (pending_commands_.empty())
         return std::nullopt;
     auto result = std::move(pending_commands_.front());
     pending_commands_.pop_front();
     return result;
+}
+
+std::optional<std::string> Descriptor::pop_incomm() {
+    auto maybe_next = pop_raw();
+    if (!maybe_next)
+        return {};
+
+    // Handle any backspace characters, newlines, or non-printing characters.
+    auto next_line = sanitise_input(*maybe_next);
+
+    if (next_line.size() > MAX_INPUT_LENGTH - 1) {
+        write("Line too long.\n\r");
+        return {};
+    }
+
+    // Do '!' substitution.
+    if (next_line[0] == '!')
+        return last_command_;
+    else {
+        last_command_ = next_line;
+        return next_line;
+    }
+}
+
+bool Descriptor::write(std::string_view text) const {
+    Packet p;
+    p.type = PACKET_MESSAGE;
+    p.channel = descriptor;
+
+    while (!text.empty()) {
+        p.nExtra = std::min<uint32_t>(text.length(), PACKET_MAX_PAYLOAD_SIZE);
+        if (!SendPacket(&p, text.data()))
+            return false;
+        text = text.substr(p.nExtra);
+    }
+    return true;
 }

--- a/src/Descriptor.hpp
+++ b/src/Descriptor.hpp
@@ -39,6 +39,9 @@ const char *name_of(DescriptorState state);
 struct Descriptor {
     static constexpr size_t MaxInbufBacklog = 50u;
     std::list<std::string> pending_commands_;
+    std::string last_command_;
+
+    [[nodiscard]] std::optional<std::string> pop_raw();
 
 public:
     Descriptor *next{};
@@ -52,8 +55,6 @@ public:
     DescriptorState connected{DescriptorState::GetName};
     uint16_t localport{};
     bool fcommand{};
-    char incomm[MAX_INPUT_LENGTH]{};
-    char inlast[MAX_INPUT_LENGTH]{};
     int repeat{};
     char *outbuf{};
     int outsize{2000};
@@ -63,9 +64,12 @@ public:
 
     explicit Descriptor(uint32_t descriptor);
     ~Descriptor();
+
     [[nodiscard]] bool is_playing() const noexcept { return connected == DescriptorState::Playing; }
     [[nodiscard]] bool is_input_full() const noexcept { return pending_commands_.size() >= MaxInbufBacklog; }
     void clear_input() { pending_commands_.clear(); }
     void add_command(std::string_view command) { pending_commands_.emplace_back(command); }
-    [[nodiscard]] std::optional<std::string> pop_pending();
+    [[nodiscard]] std::optional<std::string> pop_incomm();
+
+    bool write(std::string_view text) const;
 };

--- a/src/DescriptorData.cpp
+++ b/src/DescriptorData.cpp
@@ -50,3 +50,17 @@ const char *name_of(DescriptorState state) {
     }
     return "Unknown";
 }
+
+Descriptor::Descriptor(uint32_t descriptor) {
+    this->descriptor = descriptor;
+    outbuf = (char *)alloc_mem(outsize);
+    logintime = str_dup((char *)ctime(&current_time));
+    host = str_dup("(unknown)");
+}
+
+Descriptor::~Descriptor() {
+    free_string(host);
+    /* RT socket leak fix -- I hope */
+    free_mem(outbuf, outsize);
+    /*    free_string(dclose->showstr_head); */
+}

--- a/src/DescriptorData.cpp
+++ b/src/DescriptorData.cpp
@@ -1,0 +1,1 @@
+#include "DescriptorData.hpp"

--- a/src/DescriptorData.cpp
+++ b/src/DescriptorData.cpp
@@ -1,1 +1,52 @@
 #include "DescriptorData.hpp"
+
+// Up to 5 characters
+const char *short_name_of(DescriptorState state) {
+    switch (state) {
+    case DescriptorState::Playing: return "Play";
+    case DescriptorState::GetName: return "Name";
+    case DescriptorState::GetOldPassword: return "OldPw";
+    case DescriptorState::ConfirmNewName: return "CnfNm";
+    case DescriptorState::GetNewPassword: return "NewPw";
+    case DescriptorState::ConfirmNewPassword: return "CnfNp";
+    case DescriptorState::GetNewRace: return "GetNR";
+    case DescriptorState::GetNewSex: return "GetNS";
+    case DescriptorState::GetNewClass: return "GetNA";
+    case DescriptorState::GetAlignment: return "GetAl";
+    case DescriptorState::DefaultChoice: return "DefCh";
+    case DescriptorState::GenGroups: return "GenGr";
+    case DescriptorState::ReadIMotd: return "Imotd";
+    case DescriptorState::ReadMotd: return "Motd";
+    case DescriptorState::BreakConnect: return "BrkCn";
+    case DescriptorState::GetAnsi: return "Ansi";
+    case DescriptorState::CircumventPassword: return "CPass";
+    case DescriptorState::Disconnecting: return "Disc";
+    case DescriptorState::DisconnectingNp: return "DiscN";
+    }
+    return "<UNK>";
+}
+
+const char *name_of(DescriptorState state) {
+    switch (state) {
+    case DescriptorState::Playing: return "Playing";
+    case DescriptorState::GetName: return "GetName";
+    case DescriptorState::GetOldPassword: return "GetOldPassword";
+    case DescriptorState::ConfirmNewName: return "ConfirmNewName";
+    case DescriptorState::GetNewPassword: return "GetNewPassword";
+    case DescriptorState::ConfirmNewPassword: return "ConfirmNewPassword";
+    case DescriptorState::GetNewRace: return "GetNewRace";
+    case DescriptorState::GetNewSex: return "GetNewSex";
+    case DescriptorState::GetNewClass: return "GetNewClass";
+    case DescriptorState::GetAlignment: return "GetAlignment";
+    case DescriptorState::DefaultChoice: return "DefaultChoice";
+    case DescriptorState::GenGroups: return "GenGroups";
+    case DescriptorState::ReadIMotd: return "ReadIMotd";
+    case DescriptorState::ReadMotd: return "ReadMotd";
+    case DescriptorState::BreakConnect: return "BreakConnect";
+    case DescriptorState::GetAnsi: return "GetAnsi";
+    case DescriptorState::CircumventPassword: return "CircumventPassword";
+    case DescriptorState::Disconnecting: return "Disconnecting";
+    case DescriptorState::DisconnectingNp: return "DisconnectingNp";
+    }
+    return "Unknown";
+}

--- a/src/DescriptorData.cpp
+++ b/src/DescriptorData.cpp
@@ -64,3 +64,11 @@ Descriptor::~Descriptor() {
     free_mem(outbuf, outsize);
     /*    free_string(dclose->showstr_head); */
 }
+
+std::optional<std::string> Descriptor::pop_pending() {
+    if (pending_commands_.empty())
+        return std::nullopt;
+    auto result = std::move(pending_commands_.front());
+    pending_commands_.pop_front();
+    return result;
+}

--- a/src/DescriptorData.hpp
+++ b/src/DescriptorData.hpp
@@ -32,26 +32,28 @@ const char *name_of(DescriptorState state);
  * Descriptor (channel) structure.
  */
 struct Descriptor {
-    Descriptor *next;
-    Descriptor *snoop_by;
-    CHAR_DATA *character;
-    CHAR_DATA *original;
-    char *host;
-    char *logintime;
-    uint32_t descriptor;
-    int netaddr;
-    DescriptorState connected;
-    uint16_t localport;
-    bool fcommand;
-    char inbuf[4 * MAX_INPUT_LENGTH];
-    char incomm[MAX_INPUT_LENGTH];
-    char inlast[MAX_INPUT_LENGTH];
-    int repeat;
-    char *outbuf;
-    int outsize;
-    int outtop;
-    char *showstr_head;
-    char *showstr_point;
+    Descriptor *next{};
+    Descriptor *snoop_by{};
+    CHAR_DATA *character{};
+    CHAR_DATA *original{};
+    char *host{};
+    char *logintime{};
+    uint32_t descriptor{};
+    uint32_t netaddr{};
+    DescriptorState connected{DescriptorState::GetName};
+    uint16_t localport{};
+    bool fcommand{};
+    char inbuf[4 * MAX_INPUT_LENGTH]{};
+    char incomm[MAX_INPUT_LENGTH]{};
+    char inlast[MAX_INPUT_LENGTH]{};
+    int repeat{};
+    char *outbuf{};
+    int outsize{2000};
+    int outtop{};
+    char *showstr_head{};
+    char *showstr_point{};
 
+    explicit Descriptor(uint32_t descriptor);
+    ~Descriptor();
     [[nodiscard]] bool is_playing() const noexcept { return connected == DescriptorState::Playing; }
 };

--- a/src/DescriptorData.hpp
+++ b/src/DescriptorData.hpp
@@ -2,9 +2,7 @@
 
 #include "merc.h"
 
-/*
- * Connected state for a channel.
- */
+// Connected state for a descriptor.
 #define CON_PLAYING 0
 #define CON_GET_NAME 1
 #define CON_GET_OLD_PASSWORD 2
@@ -50,4 +48,6 @@ struct Descriptor {
     int outtop;
     char *showstr_head;
     char *showstr_point;
+
+    [[nodiscard]] bool is_playing() const noexcept { return connected == CON_PLAYING; }
 };

--- a/src/DescriptorData.hpp
+++ b/src/DescriptorData.hpp
@@ -29,9 +29,9 @@
 /*
  * Descriptor (channel) structure.
  */
-struct DESCRIPTOR_DATA {
-    DESCRIPTOR_DATA *next;
-    DESCRIPTOR_DATA *snoop_by;
+struct Descriptor {
+    Descriptor *next;
+    Descriptor *snoop_by;
     CHAR_DATA *character;
     CHAR_DATA *original;
     char *host;

--- a/src/DescriptorData.hpp
+++ b/src/DescriptorData.hpp
@@ -3,26 +3,30 @@
 #include "merc.h"
 
 // Connected state for a descriptor.
-#define CON_PLAYING 0
-#define CON_GET_NAME 1
-#define CON_GET_OLD_PASSWORD 2
-#define CON_CONFIRM_NEW_NAME 3
-#define CON_GET_NEW_PASSWORD 4
-#define CON_CONFIRM_NEW_PASSWORD 5
-#define CON_GET_NEW_RACE 6
-#define CON_GET_NEW_SEX 7
-#define CON_GET_NEW_CLASS 8
-#define CON_GET_ALIGNMENT 9
-#define CON_DEFAULT_CHOICE 10
-#define CON_GEN_GROUPS 11
-#define CON_PICK_WEAPON 12
-#define CON_READ_IMOTD 13
-#define CON_READ_MOTD 14
-#define CON_BREAK_CONNECT 15
-#define CON_GET_ANSI 16
-#define CON_CIRCUMVENT_PASSWORD 18 // used by doorman
-#define CON_DISCONNECTING 254 // disconnecting having been playing
-#define CON_DISCONNECTING_NP 255 // disconnecting before playing
+enum class DescriptorState {
+    Playing = 0,
+    GetName = 1,
+    GetOldPassword = 2,
+    ConfirmNewName = 3,
+    GetNewPassword = 4,
+    ConfirmNewPassword = 5,
+    GetNewRace = 6,
+    GetNewSex = 7,
+    GetNewClass = 8,
+    GetAlignment = 9,
+    DefaultChoice = 10,
+    GenGroups = 11,
+    ReadIMotd = 13,
+    ReadMotd = 14,
+    BreakConnect = 15,
+    GetAnsi = 16,
+    CircumventPassword = 18, // used by doorman
+    Disconnecting = 254, // disconnecting having been playing
+    DisconnectingNp = 255, // disconnecting before playing
+};
+
+const char *short_name_of(DescriptorState state);
+const char *name_of(DescriptorState state);
 
 /*
  * Descriptor (channel) structure.
@@ -36,8 +40,8 @@ struct Descriptor {
     char *logintime;
     uint32_t descriptor;
     int netaddr;
-    sh_int connected;
-    sh_int localport;
+    DescriptorState connected;
+    uint16_t localport;
     bool fcommand;
     char inbuf[4 * MAX_INPUT_LENGTH];
     char incomm[MAX_INPUT_LENGTH];
@@ -49,5 +53,5 @@ struct Descriptor {
     char *showstr_head;
     char *showstr_point;
 
-    [[nodiscard]] bool is_playing() const noexcept { return connected == CON_PLAYING; }
+    [[nodiscard]] bool is_playing() const noexcept { return connected == DescriptorState::Playing; }
 };

--- a/src/DescriptorData.hpp
+++ b/src/DescriptorData.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "merc.h"
+
+/*
+ * Connected state for a channel.
+ */
+#define CON_PLAYING 0
+#define CON_GET_NAME 1
+#define CON_GET_OLD_PASSWORD 2
+#define CON_CONFIRM_NEW_NAME 3
+#define CON_GET_NEW_PASSWORD 4
+#define CON_CONFIRM_NEW_PASSWORD 5
+#define CON_GET_NEW_RACE 6
+#define CON_GET_NEW_SEX 7
+#define CON_GET_NEW_CLASS 8
+#define CON_GET_ALIGNMENT 9
+#define CON_DEFAULT_CHOICE 10
+#define CON_GEN_GROUPS 11
+#define CON_PICK_WEAPON 12
+#define CON_READ_IMOTD 13
+#define CON_READ_MOTD 14
+#define CON_BREAK_CONNECT 15
+#define CON_GET_ANSI 16
+#define CON_CIRCUMVENT_PASSWORD 18 // used by doorman
+#define CON_DISCONNECTING 254 // disconnecting having been playing
+#define CON_DISCONNECTING_NP 255 // disconnecting before playing
+
+/*
+ * Descriptor (channel) structure.
+ */
+struct DESCRIPTOR_DATA {
+    DESCRIPTOR_DATA *next;
+    DESCRIPTOR_DATA *snoop_by;
+    CHAR_DATA *character;
+    CHAR_DATA *original;
+    char *host;
+    char *logintime;
+    uint32_t descriptor;
+    int netaddr;
+    sh_int connected;
+    sh_int localport;
+    bool fcommand;
+    char inbuf[4 * MAX_INPUT_LENGTH];
+    char incomm[MAX_INPUT_LENGTH];
+    char inlast[MAX_INPUT_LENGTH];
+    int repeat;
+    char *outbuf;
+    int outsize;
+    int outtop;
+    char *showstr_head;
+    char *showstr_point;
+};

--- a/src/act_comm.cpp
+++ b/src/act_comm.cpp
@@ -127,7 +127,7 @@ void announce(const char *buf, CHAR_DATA *ch) {
 
         victim = d->original ? d->original : d->character;
 
-        if (d->connected == CON_PLAYING && d->character != ch && victim && can_see(victim, ch)
+        if (d->is_playing() && d->character != ch && victim && can_see(victim, ch)
             && !IS_SET(victim->comm, COMM_NOANNOUNCE) && !IS_SET(victim->comm, COMM_QUIET)) {
             act_new(buf, victim, nullptr, ch, TO_CHAR, POS_DEAD);
         }
@@ -264,7 +264,7 @@ void do_yell(CHAR_DATA *ch, const char *argument) {
 
     act("|WYou yell '$t|W'|w", ch, argument, nullptr, TO_CHAR);
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        if (d->connected == CON_PLAYING && d->character != ch && d->character->in_room != nullptr
+        if (d->is_playing() && d->character != ch && d->character->in_room != nullptr
             && d->character->in_room->area == ch->in_room->area && !IS_SET(d->character->comm, COMM_QUIET)) {
             act("|W$n yells '$t|W'|w", ch, argument, d->character, TO_VICT);
         }

--- a/src/act_comm.cpp
+++ b/src/act_comm.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "merc.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/act_comm.cpp
+++ b/src/act_comm.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "merc.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/act_comm.cpp
+++ b/src/act_comm.cpp
@@ -114,7 +114,7 @@ void do_delete(CHAR_DATA *ch, char *argument) {
 }
 
 void announce(const char *buf, CHAR_DATA *ch) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (descriptor_list == nullptr)
         return;
@@ -247,7 +247,7 @@ void do_tell(CHAR_DATA *ch, char *argument) {
 void do_reply(CHAR_DATA *ch, char *argument) { tell_to(ch, ch->reply, argument); }
 
 void do_yell(CHAR_DATA *ch, const char *argument) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (IS_SET(ch->comm, COMM_NOSHOUT)) {
         send_to_char("|cYou can't yell.|w\n\r", ch);
@@ -433,7 +433,7 @@ void do_qui(CHAR_DATA *ch, char *argument) {
 
 void do_quit(CHAR_DATA *ch, const char *arg) {
     (void)arg;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     FINGER_INFO *cur;
     bool info_found = false;
 

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -1623,7 +1623,7 @@ void do_whois(CHAR_DATA *ch, char *argument) {
         CHAR_DATA *wch;
         char const *class_name;
 
-        if (d->connected != CON_PLAYING || !can_see(ch, d->character))
+        if (!d->is_playing() || !can_see(ch, d->character))
             continue;
 
         wch = (d->original != nullptr) ? d->original : d->character;
@@ -1786,7 +1786,7 @@ void do_who(CHAR_DATA *ch, char *argument) {
          * Check for match against restrictions.
          * Don't use trust as that exposes trusted mortals.
          */
-        if (d->connected != CON_PLAYING || !can_see(ch, d->character))
+        if (!d->is_playing() || !can_see(ch, d->character))
             continue;
         /* added Faramir 13/8/96 because switched imms were visible to all*/
         if (d->original != nullptr)
@@ -1865,7 +1865,7 @@ void do_count(CHAR_DATA *ch, char *argument) {
     count = 0;
 
     for (d = descriptor_list; d != nullptr; d = d->next)
-        if (d->connected == CON_PLAYING && can_see(ch, d->character))
+        if (d->is_playing() && can_see(ch, d->character))
             count++;
 
     max_on = UMAX(count, max_on);
@@ -2020,7 +2020,7 @@ void do_where(CHAR_DATA *ch, char *argument) {
         send_to_char(buf, ch);
         found = false;
         for (d = descriptor_list; d; d = d->next) {
-            if (d->connected == CON_PLAYING && (victim = d->character) != nullptr && !IS_NPC(victim) && victim != ch
+            if (d->is_playing() && (victim = d->character) != nullptr && !IS_NPC(victim) && victim != ch
                 && victim->in_room != nullptr && victim->in_room->area == ch->in_room->area && can_see(ch, victim)) {
                 found = true;
                 snprintf(buf, sizeof(buf), "|W%-28s|w %s\n\r", victim->name, victim->in_room->name);

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -1607,7 +1607,7 @@ void do_whois(CHAR_DATA *ch, char *argument) {
     char arg[MAX_INPUT_LENGTH];
     char output[MAX_STRING_LENGTH];
     char buf[MAX_STRING_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     bool found = false;
 
     one_argument(argument, arg);
@@ -1683,7 +1683,7 @@ void do_who(CHAR_DATA *ch, char *argument) {
     char buf[MAX_STRING_LENGTH];
     char buf2[MAX_STRING_LENGTH];
     char output[4 * MAX_STRING_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     int iClass;
     int iRace;
     int iClan;
@@ -1859,7 +1859,7 @@ void do_who(CHAR_DATA *ch, char *argument) {
 void do_count(CHAR_DATA *ch, char *argument) {
     (void)argument;
     int count;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     char buf[MAX_STRING_LENGTH];
 
     count = 0;
@@ -2010,7 +2010,7 @@ void do_where(CHAR_DATA *ch, char *argument) {
     char buf[MAX_STRING_LENGTH];
     char arg[MAX_INPUT_LENGTH];
     CHAR_DATA *victim;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     bool found;
 
     one_argument(argument, arg);

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "interp.h"

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "interp.h"

--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -3493,8 +3493,8 @@ void do_sockets(CHAR_DATA *ch, char *argument) {
             && (arg[0] == '\0' || is_name(arg, d->character->name)
                 || (d->original && is_name(arg, d->original->name)))) {
             count++;
-            bug_snprintf(buf + strlen(buf), sizeof(buf), "[%3d %8u %2d] %s@%s\n\r", d->descriptor,
-                         (d->localport & 0xffff), d->connected,
+            bug_snprintf(buf + strlen(buf), sizeof(buf), "[%3d %5u %5s] %s@%s\n\r", d->descriptor, d->localport,
+                         short_name_of(d->connected),
                          d->original ? d->original->name : d->character ? d->character->name : "(none)",
                          get_masked_hostname(hostbuf, d->host));
         } else if (d->character == nullptr && get_trust(ch) == MAX_LEVEL) {
@@ -3503,8 +3503,8 @@ void do_sockets(CHAR_DATA *ch, char *argument) {
              * Level 100s only, mind
              */
             count++;
-            bug_snprintf(buf + strlen(buf), sizeof(buf), "[%3d %8u %2d] (unknown)@%s\n\r", d->descriptor,
-                         (d->localport & 0xffff), d->connected, get_masked_hostname(hostbuf, d->host));
+            bug_snprintf(buf + strlen(buf), sizeof(buf), "[%3d %5u %5s] (unknown)@%s\n\r", d->descriptor, d->localport,
+                         short_name_of(d->connected), get_masked_hostname(hostbuf, d->host));
         }
     }
     if (count == 0) {

--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "flags.h"

--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "flags.h"

--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -225,7 +225,7 @@ void do_deny(CHAR_DATA *ch, const char *argument) {
 
 void do_disconnect(CHAR_DATA *ch, char *argument) {
     char arg[MAX_INPUT_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     CHAR_DATA *victim;
 
     one_argument(argument, arg);
@@ -315,7 +315,7 @@ void do_pardon(CHAR_DATA *ch, char *argument) {
 }
 
 void do_echo(CHAR_DATA *ch, char *argument) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (argument[0] == '\0') {
         send_to_char("Global echo what?\n\r", ch);
@@ -333,7 +333,7 @@ void do_echo(CHAR_DATA *ch, char *argument) {
 }
 
 void do_recho(CHAR_DATA *ch, char *argument) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (argument[0] == '\0') {
         send_to_char("Local echo what?\n\r", ch);
@@ -352,7 +352,7 @@ void do_recho(CHAR_DATA *ch, char *argument) {
 }
 
 void do_zecho(CHAR_DATA *ch, char *argument) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (argument[0] == '\0') {
         send_to_char("Zone echo what?\n\r", ch);
@@ -419,7 +419,7 @@ void do_transfer(CHAR_DATA *ch, char *argument) {
     char arg1[MAX_INPUT_LENGTH];
     char arg2[MAX_INPUT_LENGTH];
     ROOM_INDEX_DATA *location;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     CHAR_DATA *victim;
 
     argument = one_argument(argument, arg1);
@@ -1665,7 +1665,7 @@ void do_shutdown(CHAR_DATA *ch, char *argument) {
     (void)argument;
     char buf[MAX_STRING_LENGTH];
     extern bool merc_down;
-    DESCRIPTOR_DATA *d, *d_next;
+    Descriptor *d, *d_next;
 
     bug_snprintf(buf, sizeof(buf), "Shutdown by %s.", ch->name);
     append_file(ch, SHUTDOWN_FILE, buf);
@@ -1683,7 +1683,7 @@ void do_shutdown(CHAR_DATA *ch, char *argument) {
 
 void do_snoop(CHAR_DATA *ch, char *argument) {
     char arg[MAX_INPUT_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     CHAR_DATA *victim;
 
     one_argument(argument, arg);
@@ -2016,7 +2016,7 @@ void do_purge(CHAR_DATA *ch, const char *argument) {
     char buf[100];
     CHAR_DATA *victim;
     OBJ_DATA *obj;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     one_argument(argument, arg);
 
@@ -2204,7 +2204,7 @@ void do_restore(CHAR_DATA *ch, char *argument) {
     char arg[MAX_INPUT_LENGTH];
     CHAR_DATA *victim;
     CHAR_DATA *vch;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     one_argument(argument, arg);
     if (arg[0] == '\0' || !str_cmp(arg, "room")) {
@@ -3481,7 +3481,7 @@ void do_sockets(CHAR_DATA *ch, char *argument) {
     char buf2[MAX_STRING_LENGTH];
     char arg[MAX_INPUT_LENGTH];
     char hostbuf[MAX_MASKED_HOSTNAME];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     int count;
 
     count = 0;

--- a/src/act_wiz.cpp
+++ b/src/act_wiz.cpp
@@ -323,7 +323,7 @@ void do_echo(CHAR_DATA *ch, char *argument) {
     }
 
     for (d = descriptor_list; d; d = d->next) {
-        if (d->connected == CON_PLAYING) {
+        if (d->is_playing()) {
             if (get_trust(d->character) >= get_trust(ch))
                 send_to_char("global> ", d->character);
             send_to_char(argument, d->character);
@@ -342,7 +342,7 @@ void do_recho(CHAR_DATA *ch, char *argument) {
     }
 
     for (d = descriptor_list; d; d = d->next) {
-        if (d->connected == CON_PLAYING && d->character->in_room == ch->in_room) {
+        if (d->is_playing() && d->character->in_room == ch->in_room) {
             if (get_trust(d->character) >= get_trust(ch) && ch->in_room->vnum != 1222)
                 send_to_char("local> ", d->character);
             send_to_char(argument, d->character);
@@ -360,7 +360,7 @@ void do_zecho(CHAR_DATA *ch, char *argument) {
     }
 
     for (d = descriptor_list; d; d = d->next) {
-        if (d->connected == CON_PLAYING && d->character->in_room != nullptr && ch->in_room != nullptr
+        if (d->is_playing() && d->character->in_room != nullptr && ch->in_room != nullptr
             && d->character->in_room->area == ch->in_room->area) {
             if (get_trust(d->character) >= get_trust(ch))
                 send_to_char("zone> ", d->character);
@@ -432,7 +432,7 @@ void do_transfer(CHAR_DATA *ch, char *argument) {
 
     if (!str_cmp(arg1, "all")) {
         for (d = descriptor_list; d != nullptr; d = d->next) {
-            if (d->connected == CON_PLAYING && d->character != ch && d->character->in_room != nullptr
+            if (d->is_playing() && d->character != ch && d->character->in_room != nullptr
                 && can_see(ch, d->character)) {
                 char buf[MAX_STRING_LENGTH];
                 bug_snprintf(buf, sizeof(buf), "%s %s", d->character->name, arg2);

--- a/src/challeng.cpp
+++ b/src/challeng.cpp
@@ -7,6 +7,7 @@
 /*              Wandera. Revised by Oshea 26/8/96                        */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "merc.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/challeng.cpp
+++ b/src/challeng.cpp
@@ -7,7 +7,7 @@
 /*              Wandera. Revised by Oshea 26/8/96                        */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "merc.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -128,7 +128,7 @@ void channel_command(CHAR_DATA *ch, const char *argument, int chan_flag, const c
 
             victim = d->original ? d->original : d->character;
 
-            if (d->connected == CON_PLAYING && d->character != ch && !IS_SET(victim->comm, chan_flag)
+            if (d->is_playing() && d->character != ch && !IS_SET(victim->comm, chan_flag)
                 && !IS_SET(victim->comm, COMM_QUIET)) {
                 act_new(desc_other, ch, argument, d->character, TO_VICT, POS_DEAD);
             }
@@ -158,7 +158,7 @@ void do_immtalk(CHAR_DATA *ch, const char *argument) {
     if (get_trust(ch) >= 91)
         act_new(format, ch, argument, nullptr, TO_CHAR, POS_DEAD);
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        if (d->connected == CON_PLAYING && IS_IMMORTAL(d->character) && !IS_SET(d->character->comm, COMM_NOWIZ)) {
+        if (d->is_playing() && IS_IMMORTAL(d->character) && !IS_SET(d->character->comm, COMM_NOWIZ)) {
             act_new(format, ch, argument, d->character, TO_VICT, POS_DEAD);
         }
     }

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "interp.h"
 #include "merc.h"
 

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "interp.h"
 #include "merc.h"
 

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -107,7 +107,7 @@ void channel_command(CHAR_DATA *ch, const char *argument, int chan_flag, const c
     if (argument[0] == '\0') {
         toggle_channel(ch, chan_flag, chan_name);
     } else {
-        DESCRIPTOR_DATA *d;
+        Descriptor *d;
 
         if (IS_SET(ch->comm, COMM_QUIET)) {
             send_to_char("You must turn off quiet mode first.\n\r", ch);
@@ -142,7 +142,7 @@ void do_announce(CHAR_DATA *ch, const char *argument) {
 }
 
 void do_immtalk(CHAR_DATA *ch, const char *argument) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     const char *format = "|W$n: |c$t|w";
 
     if (argument[0] == '\0') {

--- a/src/clan.cpp
+++ b/src/clan.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "interp.h"
 #include "merc.h"
 #include <cstdio>

--- a/src/clan.cpp
+++ b/src/clan.cpp
@@ -57,7 +57,7 @@ void do_clantalk(CHAR_DATA *ch, char *argument) {
 
     char buf[MAX_STRING_LENGTH];
     int candoit = 0;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     PCCLAN *OrigClan;
 
     if (IS_NPC(ch)) {
@@ -335,7 +335,7 @@ void do_demote(CHAR_DATA *ch, char *argument) { mote(ch, argument, -1); }
 
 void do_clanwho(CHAR_DATA *ch, char *argument) {
     (void)argument;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     CHAR_DATA *wch;
     char buf[MAX_STRING_LENGTH];
 

--- a/src/clan.cpp
+++ b/src/clan.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "interp.h"
 #include "merc.h"
 #include <cstdio>

--- a/src/clan.cpp
+++ b/src/clan.cpp
@@ -124,7 +124,7 @@ void do_clantalk(CHAR_DATA *ch, char *argument) {
         CHAR_DATA *vix;
         vix = d->original ? d->original : d->character;
 
-        if ((d->connected == CON_PLAYING) && (vix->pcdata->pcclan)
+        if ((d->is_playing()) && (vix->pcdata->pcclan)
             && (vix->pcdata->pcclan->clan->clanchar == OrigClan->clan->clanchar)
             && (vix->pcdata->pcclan->channelflags & CLANCHANNEL_ON) && !IS_SET(vix->comm, COMM_QUIET)
             /* || they're an IMM snooping the channels */) {
@@ -350,7 +350,7 @@ void do_clanwho(CHAR_DATA *ch, char *argument) {
     send_to_char("|gCharacter name     |c|||g Clan level|w\n\r", ch);
     send_to_char("|c-------------------+-------------------------------|w\n\r", ch);
     for (d = descriptor_list; d; d = d->next) {
-        if (d->connected == CON_PLAYING) {
+        if (d->is_playing()) {
             wch = (d->original) ? (d->original) : d->character;
             if ((can_see(ch, wch)) && (wch->pcdata->pcclan)
                 && (wch->pcdata->pcclan->clan->clanchar == ch->pcdata->pcclan->clan->clanchar)) {

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -12,6 +12,7 @@
  * We only support linux these days...so we stopped pretending...
  */
 
+#include "DescriptorData.hpp"
 #include <arpa/telnet.h>
 #include <cctype>
 #include <cerrno>
@@ -84,7 +85,7 @@ void nanny(DESCRIPTOR_DATA *d, const char *argument);
 bool process_output(DESCRIPTOR_DATA *d, bool fPrompt);
 void read_from_buffer(DESCRIPTOR_DATA *d);
 void show_prompt(DESCRIPTOR_DATA *d, char *prompt);
-void show_string(struct descriptor_data *d, const char *input);
+void show_string(DESCRIPTOR_DATA *d, const char *input);
 
 /* Handle to get to doorman */
 int doormanDesc = 0;
@@ -1683,7 +1684,7 @@ void page_to_char(const char *txt, CHAR_DATA *ch) {
 }
 
 /* string pager */
-void show_string(struct descriptor_data *d, const char *input) {
+void show_string(DESCRIPTOR_DATA *d, const char *input) {
     char buffer[4 * MAX_STRING_LENGTH];
     char buf[MAX_INPUT_LENGTH];
     char *scan, *chk;

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -449,7 +449,7 @@ void game_loop_unix(int control) {
             if (d->character && d->character->wait)
                 continue;
 
-            if (auto incomm = d->pop_incomm(); incomm) {
+            if (auto incomm = d->pop_incomm()) {
                 d->fcommand = true;
                 move_active_char_from_limbo(d->character);
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -133,7 +133,7 @@ void handle_signal_shutdown() {
 
         // vch->d->c check added by TM to avoid crashes when
         // someone hasn't logged in but the mud is shut down
-        if (!IS_NPC(vch) && vch->desc && vch->desc->connected == CON_PLAYING) {
+        if (!IS_NPC(vch) && vch->desc && vch->desc->is_playing()) {
             /* Merc-2.2 MOBProgs - Faramir 31/8/1998 */
             MOBtrigger = false;
             do_save(vch, "");
@@ -376,7 +376,7 @@ void game_loop_unix(int control) {
                                 if (d->character && d->character->level > 1)
                                     save_char_obj(d->character);
                                 d->outtop = 0;
-                                if (d->connected == CON_PLAYING)
+                                if (d->is_playing())
                                     d->connected = CON_DISCONNECTING;
                                 else
                                     d->connected = CON_DISCONNECTING_NP;
@@ -456,7 +456,7 @@ void game_loop_unix(int control) {
 
                 if (d->showstr_point)
                     show_string(d, d->incomm);
-                else if (d->connected == CON_PLAYING)
+                else if (d->is_playing())
                     interpret(d->character, d->incomm);
                 else
                     nanny(d, d->incomm);
@@ -599,7 +599,7 @@ void close_socket(Descriptor *dclose) {
         snprintf(log_buf, LOG_BUF_SIZE, "Closing link to %s.", ch->name);
         log_new(log_buf, EXTRA_WIZNET_DEBUG,
                 (IS_SET(ch->act, PLR_WIZINVIS) || IS_SET(ch->act, PLR_PROWL)) ? get_trust(ch) : 0);
-        if (dclose->connected == CON_PLAYING || dclose->connected == CON_DISCONNECTING) {
+        if (dclose->is_playing() || dclose->connected == CON_DISCONNECTING) {
             act("$n has lost $s link.", ch, nullptr, nullptr, TO_ROOM);
             ch->desc = nullptr;
         } else {
@@ -754,7 +754,7 @@ bool process_output(Descriptor *d, bool fPrompt) {
      */
     if (!merc_down && d->showstr_point)
         write_to_buffer(d, "[Hit Return to continue]\n\r", 0);
-    else if (fPrompt && !merc_down && d->connected == CON_PLAYING) {
+    else if (fPrompt && !merc_down && d->is_playing()) {
         CHAR_DATA *ch;
         CHAR_DATA *victim;
 
@@ -1453,7 +1453,7 @@ void nanny(Descriptor *d, const char *argument) {
            updated if a player did count */
         count = 0;
         for (de = descriptor_list; de != nullptr; de = de->next)
-            if (de->connected == CON_PLAYING)
+            if (de->is_playing())
                 count++;
         max_on = UMAX(count, max_on);
 

--- a/src/comm.hpp
+++ b/src/comm.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "doorman/doorman_protocol.h"
+
+bool SendPacket(Packet *p, const void *extra);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -8,6 +8,7 @@
 /*************************************************************************/
 
 #include "db.h"
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "interp.h"
 #include "merc.h"

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -8,7 +8,7 @@
 /*************************************************************************/
 
 #include "db.h"
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "interp.h"
 #include "merc.h"

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2780,7 +2780,7 @@ void do_dump(CHAR_DATA *ch, char *argument) {
     OBJ_INDEX_DATA *pObjIndex;
     ROOM_INDEX_DATA *room;
     EXIT_DATA *exit;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     AFFECT_DATA *af;
     FILE *fp;
     int vnum, nMatch = 0;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2823,14 +2823,10 @@ void do_dump(CHAR_DATA *ch, char *argument) {
 
     /* descriptors */
     count = 0;
-    count2 = 0;
     for (d = descriptor_list; d != nullptr; d = d->next)
         count++;
-    for (d = descriptor_free; d != nullptr; d = d->next)
-        count2++;
 
-    fprintf(fp, "Descs	%4d (%8ld bytes), %2d free (%ld bytes)\n", count, count * (sizeof(*d)), count2,
-            count2 * (sizeof(*d)));
+    fprintf(fp, "Descs	%4d (%8ld bytes)\n", count, count * (sizeof(*d)));
 
     /* object prototypes */
     for (vnum = 0; nMatch < top_obj_index; vnum++)

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/interp.cpp
+++ b/src/interp.cpp
@@ -8,7 +8,7 @@
 /*************************************************************************/
 
 #include "interp.h"
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "merc.h"
 #include "note.h"
 #include "trie.h"

--- a/src/interp.cpp
+++ b/src/interp.cpp
@@ -8,6 +8,7 @@
 /*************************************************************************/
 
 #include "interp.h"
+#include "DescriptorData.hpp"
 #include "merc.h"
 #include "note.h"
 #include "trie.h"

--- a/src/merc.h
+++ b/src/merc.h
@@ -67,7 +67,7 @@ typedef struct affect_data AFFECT_DATA;
 typedef struct area_data AREA_DATA;
 typedef struct ban_data BAN_DATA;
 typedef struct char_data CHAR_DATA;
-typedef struct descriptor_data DESCRIPTOR_DATA;
+struct DESCRIPTOR_DATA;
 typedef struct exit_data EXIT_DATA;
 typedef struct extra_descr_data EXTRA_DESCR_DATA;
 typedef struct help_data HELP_DATA;
@@ -192,56 +192,6 @@ struct weather_data {
     int change;
     int sky;
     int sunlight;
-};
-
-/*
- * Connected state for a channel.
- */
-#define CON_PLAYING 0
-#define CON_GET_NAME 1
-#define CON_GET_OLD_PASSWORD 2
-#define CON_CONFIRM_NEW_NAME 3
-#define CON_GET_NEW_PASSWORD 4
-#define CON_CONFIRM_NEW_PASSWORD 5
-#define CON_GET_NEW_RACE 6
-#define CON_GET_NEW_SEX 7
-#define CON_GET_NEW_CLASS 8
-#define CON_GET_ALIGNMENT 9
-#define CON_DEFAULT_CHOICE 10
-#define CON_GEN_GROUPS 11
-#define CON_PICK_WEAPON 12
-#define CON_READ_IMOTD 13
-#define CON_READ_MOTD 14
-#define CON_BREAK_CONNECT 15
-#define CON_GET_ANSI 16
-#define CON_CIRCUMVENT_PASSWORD 18 // used by doorman
-#define CON_DISCONNECTING 254 // disconnecting having been playing
-#define CON_DISCONNECTING_NP 255 // disconnecting before playing
-
-/*
- * Descriptor (channel) structure.
- */
-struct descriptor_data {
-    DESCRIPTOR_DATA *next;
-    DESCRIPTOR_DATA *snoop_by;
-    CHAR_DATA *character;
-    CHAR_DATA *original;
-    char *host;
-    char *logintime;
-    uint32_t descriptor;
-    int netaddr;
-    sh_int connected;
-    sh_int localport;
-    bool fcommand;
-    char inbuf[4 * MAX_INPUT_LENGTH];
-    char incomm[MAX_INPUT_LENGTH];
-    char inlast[MAX_INPUT_LENGTH];
-    int repeat;
-    char *outbuf;
-    int outsize;
-    int outtop;
-    char *showstr_head;
-    char *showstr_point;
 };
 
 /*

--- a/src/merc.h
+++ b/src/merc.h
@@ -67,7 +67,7 @@ typedef struct affect_data AFFECT_DATA;
 typedef struct area_data AREA_DATA;
 typedef struct ban_data BAN_DATA;
 typedef struct char_data CHAR_DATA;
-struct DESCRIPTOR_DATA;
+struct Descriptor;
 typedef struct exit_data EXIT_DATA;
 typedef struct extra_descr_data EXTRA_DESCR_DATA;
 typedef struct help_data HELP_DATA;
@@ -1192,7 +1192,7 @@ struct char_data {
     CHAR_DATA *ridden_by;
     SpecialFunc spec_fun;
     MOB_INDEX_DATA *pIndexData;
-    DESCRIPTOR_DATA *desc;
+    Descriptor *desc;
     AFFECT_DATA *affected;
     NOTE_DATA *pnote;
     OBJ_DATA *carrying;
@@ -1824,7 +1824,7 @@ extern SHOP_DATA *shop_first;
 
 extern BAN_DATA *ban_list;
 extern CHAR_DATA *char_list;
-extern DESCRIPTOR_DATA *descriptor_list;
+extern Descriptor *descriptor_list;
 extern OBJ_DATA *object_list;
 
 extern AFFECT_DATA *affect_free;
@@ -1832,7 +1832,7 @@ extern AFFECT_DATA *affect_free;
 extern BAN_DATA *ban_free;
 
 extern CHAR_DATA *char_free;
-extern DESCRIPTOR_DATA *descriptor_free;
+extern Descriptor *descriptor_free;
 extern EXTRA_DESCR_DATA *extra_descr_free;
 extern OBJ_DATA *obj_free;
 extern PC_DATA *pcdata_free;
@@ -1928,8 +1928,8 @@ void ban_site(CHAR_DATA *ch, const char *site, bool fType);
 #define MAX_MASKED_HOSTNAME 64
 unsigned long djb2_hash(const char *str);
 char *get_masked_hostname(char *hostbuf, const char *hostname);
-void close_socket(DESCRIPTOR_DATA *dclose);
-void write_to_buffer(DESCRIPTOR_DATA *d, const char *txt, int length);
+void close_socket(Descriptor *dclose);
+void write_to_buffer(Descriptor *d, const char *txt, int length);
 void send_to_char(const char *txt, CHAR_DATA *ch);
 void page_to_char(const char *txt, CHAR_DATA *ch);
 void act(const char *format, CHAR_DATA *ch, const void *arg1, const void *arg2, int type);
@@ -2096,7 +2096,7 @@ void obj_cast_spell(int sn, int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 
 /* save.c */
 void save_char_obj(CHAR_DATA *ch);
-bool load_char_obj(DESCRIPTOR_DATA *d, const char *name);
+bool load_char_obj(Descriptor *d, const char *name);
 
 /* skills.c */
 bool parse_gen_groups(CHAR_DATA *ch, const char *argument);

--- a/src/merc.h
+++ b/src/merc.h
@@ -1832,7 +1832,6 @@ extern AFFECT_DATA *affect_free;
 extern BAN_DATA *ban_free;
 
 extern CHAR_DATA *char_free;
-extern Descriptor *descriptor_free;
 extern EXTRA_DESCR_DATA *extra_descr_free;
 extern OBJ_DATA *obj_free;
 extern PC_DATA *pcdata_free;

--- a/src/mob_commands.cpp
+++ b/src/mob_commands.cpp
@@ -503,7 +503,7 @@ void do_mptransfer(CHAR_DATA *ch, char *argument) {
     char arg1[MAX_INPUT_LENGTH];
     char arg2[MAX_INPUT_LENGTH];
     ROOM_INDEX_DATA *location;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     CHAR_DATA *victim;
 
     if (!IS_NPC(ch)) {

--- a/src/mob_commands.cpp
+++ b/src/mob_commands.cpp
@@ -520,7 +520,7 @@ void do_mptransfer(CHAR_DATA *ch, char *argument) {
 
     if (!str_cmp(arg1, "all")) {
         for (d = descriptor_list; d != nullptr; d = d->next) {
-            if (d->connected == CON_PLAYING && d->character != ch && d->character->in_room != nullptr
+            if (d->is_playing() && d->character != ch && d->character->in_room != nullptr
                 && can_see(ch, d->character)) {
                 char buf[MAX_STRING_LENGTH];
                 snprintf(buf, sizeof(buf), "%s %s", d->character->name, arg2);

--- a/src/mob_commands.cpp
+++ b/src/mob_commands.cpp
@@ -18,6 +18,7 @@
  *  such installation can be found in INSTALL.  Enjoy........    N'Atas-Ha *
  ***************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "merc.h"
 #include "string_utils.hpp"
 

--- a/src/mob_commands.cpp
+++ b/src/mob_commands.cpp
@@ -18,7 +18,7 @@
  *  such installation can be found in INSTALL.  Enjoy........    N'Atas-Ha *
  ***************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "merc.h"
 #include "string_utils.hpp"
 

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "news.h"
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "flags.h"
 #include "merc.h"

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -601,7 +601,7 @@ void do_news_uncatchup(CHAR_DATA *ch, const char *argument) {
 void do_news_delete(CHAR_DATA *ch, char *argument) {
     int artnum;
     ARTICLE *art;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     THREAD *chthread;
     int n;
     if (ch->thread == nullptr) { // Check to see if char has a thread sleceted

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -630,7 +630,7 @@ void do_news_delete(CHAR_DATA *ch, char *argument) {
     /* Check to see if anyone is 'reading' this message currently, if so move them on to the next */
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *person;
-        if (d->connected == CON_PLAYING) {
+        if (d->is_playing()) {
             person = d->original ? d->original : d->character; // Find the corresponding person assoc'd with d
             if ((person != nullptr) && // Do they exist?
                 (person->article == art)) // Are they looking at this article?
@@ -657,7 +657,7 @@ void do_news_delete(CHAR_DATA *ch, char *argument) {
         /* Check to see if anyone is 'reading' this thread */
         for (d = descriptor_list; d; d = d->next) {
             CHAR_DATA *person;
-            if (d->connected == CON_PLAYING) {
+            if (d->is_playing()) {
                 person = d->original ? d->original : d->character; // Find the corresponding person assoc'd with d
                 if ((person != nullptr) && // Do they exist?
                     (person->thread == chthread)) { // Are they looking at this thread?

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "news.h"
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "flags.h"
 #include "merc.h"

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -341,7 +341,7 @@ void note_announce(CHAR_DATA *chsender, NOTE_DATA *note) {
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *chtarg;
         chtarg = d->original ? d->original : d->character;
-        if (d->connected == CON_PLAYING && d->character != chsender && chtarg && !IS_SET(chtarg->comm, COMM_NOANNOUNCE)
+        if (d->is_playing() && d->character != chsender && chtarg && !IS_SET(chtarg->comm, COMM_NOANNOUNCE)
             && !IS_SET(chtarg->comm, COMM_QUIET) && is_note_to(chtarg, note)) {
             send_to_char("The Spirit of Hermes announces the arrival of a new note.\n\r", chtarg);
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -332,7 +332,7 @@ static void note_post(CHAR_DATA *ch, const char *argument) {
 }
 
 void note_announce(CHAR_DATA *chsender, NOTE_DATA *note) {
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     if (note == nullptr) {
         log_string("note_announce() note is null");

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -8,6 +8,7 @@
 /*************************************************************************/
 
 #include "note.h"
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -8,7 +8,7 @@
 /*************************************************************************/
 
 #include "note.h"
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "merc.h"
 #include "string_utils.hpp"

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -432,7 +432,7 @@ void fwrite_obj(CHAR_DATA *ch, OBJ_DATA *obj, FILE *fp, int iNest) {
 /*
  * Load a char and inventory into a new ch structure.
  */
-bool load_char_obj(DESCRIPTOR_DATA *d, const char *name) {
+bool load_char_obj(Descriptor *d, const char *name) {
     static PC_DATA pcdata_zero;
     char strsave[MAX_INPUT_LENGTH];
     char buf[MAX_STRING_LENGTH * 2];

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "merc.h"
 #include "news.h"
 #include <ctype.h>

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "merc.h"
 #include "news.h"
 #include <ctype.h>

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -79,3 +79,26 @@ std::string remove_last_line(std::string_view str) {
     // Else, no crlf at all, return empty.
     return "";
 }
+
+std::string sanitise_input(std::string_view str) {
+    std::string result;
+    result.reserve(str.size());
+    // Copy to result, applying any backspaces (\b) as we go. We don't combine this with dropping non-printing else
+    // users typing, then deleting bad chars get confusing results.
+    for (auto c : str) {
+        if (c == '\b') {
+            if (!result.empty())
+                result.pop_back();
+        } else {
+            result.push_back(c);
+        }
+    }
+    result.erase(std::remove_if(result.begin(), result.end(), [](char c) { return !isascii(c) || !isprint(c); }),
+                 result.end());
+
+    // TODO: is this needed? The original code had it but it seems FUDdish to me...(mrg)
+    if (result.empty())
+        result = " ";
+
+    return result;
+}

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -93,13 +93,10 @@ std::string sanitise_input(std::string_view str) {
             result.push_back(c);
         }
     }
+
+    // Remove non-printing, non-ascii characters. This awkward erase(remove_if,,,) idiom is a uniquely C++ mess.
     result.erase(std::remove_if(result.begin(), result.end(), [](char c) { return !isascii(c) || !isprint(c); }),
                  result.end());
-
-    // Empty strings are replaced with a single space. This is to discriminate between no command pending and the user
-    // hitting empty. TODO: can later use optional<string> to encode this in Descriptor.
-    if (result.empty())
-        result = " ";
 
     return result;
 }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -96,7 +96,8 @@ std::string sanitise_input(std::string_view str) {
     result.erase(std::remove_if(result.begin(), result.end(), [](char c) { return !isascii(c) || !isprint(c); }),
                  result.end());
 
-    // TODO: is this needed? The original code had it but it seems FUDdish to me...(mrg)
+    // Empty strings are replaced with a single space. This is to discriminate between no command pending and the user
+    // hitting empty. TODO: can later use optional<string> to encode this in Descriptor.
     if (result.empty())
         result = " ";
 

--- a/src/string_utils.hpp
+++ b/src/string_utils.hpp
@@ -10,6 +10,9 @@
 // Trims off the last line of a string (terminated with \n\r).
 [[nodiscard]] std::string remove_last_line(std::string_view str);
 
+// Sanitizes user input: removes non-printing characters and applies "\b" backspaces
+[[nodiscard]] std::string sanitise_input(std::string_view str);
+
 // Return true if an argument is completely numeric.
 [[nodiscard]] bool is_number(const char *arg);
 

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -101,4 +101,16 @@ TEST_CASE("Interpreter tests") {
                   == "This is a line\n\rThis is the second line\n\r");
         }
     }
+
+    SECTION("sanitizes text input") {
+        SECTION("handles simple case") { CHECK(sanitise_input("I am a fish") == "I am a fish"); }
+        SECTION("preserves leading and trailing whitespace") {
+            CHECK(sanitise_input("  I am a fish  ") == "  I am a fish  ");
+        }
+        SECTION("strips trailing CRLF") { CHECK(sanitise_input("Some string   \r\n") == "Some string   "); }
+        SECTION("converts empty strings to a single space") { CHECK(sanitise_input("") == " "); }
+        SECTION("removes non-printing") { CHECK(sanitise_input("arg\tl\u00ffe") == "argle"); }
+        SECTION("removes backspaces") { CHECK(sanitise_input("TheMa\boog sucks\b\b\b\b\b\b") == "TheMoog"); }
+        SECTION("removes backspaces after non-printing") { CHECK(sanitise_input("Oops\xff\b!") == "Oops!"); }
+    }
 }

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -6,7 +6,7 @@
 #include <string_view>
 using namespace std::literals;
 
-TEST_CASE("Interpreter tests") {
+TEST_CASE("string_util tests") {
     SECTION("should determine numbers") {
         CHECK(is_number("0"));
         CHECK(is_number("123"));
@@ -108,7 +108,8 @@ TEST_CASE("Interpreter tests") {
             CHECK(sanitise_input("  I am a fish  ") == "  I am a fish  ");
         }
         SECTION("strips trailing CRLF") { CHECK(sanitise_input("Some string   \r\n") == "Some string   "); }
-        SECTION("converts empty strings to a single space") { CHECK(sanitise_input("") == " "); }
+        SECTION("handles empty strings") { CHECK(sanitise_input("") == ""); }
+        SECTION("handles empty strings that are just non-printing") { CHECK(sanitise_input("\n\r\t") == ""); }
         SECTION("removes non-printing") { CHECK(sanitise_input("arg\tl\u00ffe") == "argle"); }
         SECTION("removes backspaces") { CHECK(sanitise_input("TheMa\boog sucks\b\b\b\b\b\b") == "TheMoog"); }
         SECTION("removes backspaces after non-printing") { CHECK(sanitise_input("Oops\xff\b!") == "Oops!"); }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "interp.h"
 #include "merc.h"
 #include <stdio.h>

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -411,7 +411,7 @@ void mobile_update() {
  */
 void weather_update() {
     char buf[MAX_STRING_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     int diff;
 
     buf[0] = '\0';

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -517,7 +517,7 @@ void weather_update() {
 
     if (buf[0] != '\0') {
         for (d = descriptor_list; d != nullptr; d = d->next) {
-            if (d->connected == CON_PLAYING && IS_OUTSIDE(d->character) && IS_AWAKE(d->character))
+            if (d->is_playing() && IS_OUTSIDE(d->character) && IS_AWAKE(d->character))
                 send_to_char(buf, d->character);
         }
     }
@@ -528,7 +528,7 @@ void weather_update() {
  * their previous room.
  */
 void move_active_char_from_limbo(CHAR_DATA *ch) {
-    if (ch == nullptr || ch->desc == nullptr || ch->desc->connected != CON_PLAYING || ch->was_in_room == nullptr
+    if (ch == nullptr || ch->desc == nullptr || !ch->desc->is_playing() || ch->was_in_room == nullptr
         || ch->in_room != get_room_index(ROOM_VNUM_LIMBO))
         return;
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "interp.h"
 #include "merc.h"
 #include <stdio.h>

--- a/src/wiznet.cpp
+++ b/src/wiznet.cpp
@@ -78,7 +78,7 @@ void log_new(const char *str, int loglevel, int level) {
 
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *ch = d->original ? d->original : d->character;
-        if ((d->connected != CON_PLAYING) || (ch == nullptr) || (IS_NPC(ch)) || !is_set_extra(ch, EXTRA_WIZNET_ON)
+        if ((!d->is_playing()) || (ch == nullptr) || (IS_NPC(ch)) || !is_set_extra(ch, EXTRA_WIZNET_ON)
             || !is_set_extra(ch, loglevel) || (get_trust(ch) < level))
             continue;
         send_to_char(buf, d->character);

--- a/src/wiznet.cpp
+++ b/src/wiznet.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/wiznet.cpp
+++ b/src/wiznet.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/wiznet.cpp
+++ b/src/wiznet.cpp
@@ -65,7 +65,7 @@ void log_string(const char *str) { log_new(str, EXTRA_WIZNET_DEBUG, 0); }
 void log_new(const char *str, int loglevel, int level) {
     char *strtime;
     char buf[MAX_STRING_LENGTH];
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
 
     strtime = ctime(&current_time);
     strtime[strlen(strtime) - 1] = '\0';

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -7,7 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "DescriptorData.hpp"
+#include "Descriptor.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "interp.h"

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -7,6 +7,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include "DescriptorData.hpp"
 #include "buffer.h"
 #include "db.h"
 #include "interp.h"

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -694,7 +694,7 @@ void web_who() {
 
         wch = (d->original != nullptr) ? d->original : d->character;
 
-        if (d->connected != CON_PLAYING || !web_see(wch))
+        if (!d->is_playing() || !web_see(wch))
             continue;
         fprintf(fp, "<TR><TD>%d</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD>\n", wch->level,
                 wch->race < MAX_PC_RACE ? pc_race_table[wch->race].who_name : "     ", class_table[wch->class_num].name,
@@ -780,7 +780,7 @@ void tip_players() {
 
         ch = (d->original != nullptr) ? d->original : d->character;
 
-        if (d->connected != CON_PLAYING)
+        if (!d->is_playing())
             continue;
 
         if (is_set_extra(ch, EXTRA_TIP_WIZARD)) {

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -674,7 +674,7 @@ bool web_see(CHAR_DATA *ch) {
 void web_who() {
 
     FILE *fp;
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     int count = 0;
 
     if ((fp = fopen(WEB_WHO_FILE, "w")) == nullptr) {
@@ -754,7 +754,7 @@ void load_tipfile() {
 
 void tip_players() {
 
-    DESCRIPTOR_DATA *d;
+    Descriptor *d;
     char buf[MAX_STRING_LENGTH];
 
     /* check the tip wizard list first ... */


### PR DESCRIPTION
A partial refactor of the descriptors. It may be beneficial to go through the change commit-by-commit as I tried to be incremental.

Highlights:

* `Descriptor` class now holds the old descriptor info.
* `Descriptor`s are `new`/`deleted`. One day we'll do something different for the global descriptor list and be smart about memory etc, but we'll suffer this to get: constructor and destructor now do useful things.
* Descriptors no longer recycled in the free list. NB I am 90% sure it's leaking the "log_name" et al. A future change to `std::string` these will fix.
* Input handling is now more sane, uses dynamic lists of strings. I limit the size of incoming strings both by the doorman max line length, the MAX_INPUT in xania (as messages are dequeued), and by not allowing more than 50 (probably too high) queued messages.
* Input handling relies on doorman only ever sending whole lines. This seems safe and sensible.
* Most fields in Descriptor are still public. I plan on changing that up.

Thoughts welcomed. Obviously a ton of further improvements can be made, but this seemed like a good enough spot to stop and poll for comments and thoughts on direction.

This goes some way to mitigate #46 I think. Will do some more testing with that, but I couldn't get anything untoward happening with this change.