### PR TITLE
Extract the CHAR_DATA fields from descriptors

### DIFF
--- a/src/Descriptor.cpp
+++ b/src/Descriptor.cpp
@@ -114,9 +114,9 @@ bool Descriptor::flush_output() noexcept {
     if (outbuf_.empty())
         return true;
 
-    if (character) {
+    if (character_) {
         for (auto *snooper : snoop_by_) {
-            snooper->write(character->name);
+            snooper->write(character_->name);
             snooper->write("> ");
             snooper->write(outbuf_);
         }
@@ -152,13 +152,13 @@ void Descriptor::page_to(std::string_view page) noexcept {
 
 void Descriptor::show_next_page(std::string_view input) noexcept {
     // Any non-empty input cancels pagination, as does having no associated character to send to.
-    if (!skip_whitespace(input).empty() || !character) {
+    if (!skip_whitespace(input).empty() || !character_) {
         page_outbuf_.clear();
         return;
     }
 
-    for (auto line = 0; !page_outbuf_.empty() && line < character->lines; ++line) {
-        send_to_char((page_outbuf_.front() + "\r\n").c_str(), character);
+    for (auto line = 0; !page_outbuf_.empty() && line < character_->lines; ++line) {
+        send_to_char((page_outbuf_.front() + "\r\n").c_str(), character_);
         page_outbuf_.pop_front();
     }
 }
@@ -199,7 +199,7 @@ void Descriptor::stop_snooping() {
 void Descriptor::close() noexcept {
     while (!snoop_by_.empty()) {
         auto &snooper = *snoop_by_.begin();
-        snooper->write("Your victim ({}) has left the game.\n\r"_format(character ? character->name : "unknown"));
+        snooper->write("Your victim ({}) has left the game.\n\r"_format(character_ ? character_->name : "unknown"));
         snooper->stop_snooping(*this);
     }
     stop_snooping();
@@ -211,4 +211,22 @@ void Descriptor::note_input(std::string_view char_name, std::string_view input) 
     auto snooped_msg = "{}% {}\n\r"_format(char_name, input);
     for (auto *snooper : snoop_by_)
         snooper->write(snooped_msg);
+}
+
+void Descriptor::do_switch(CHAR_DATA *victim) {
+    if (is_switched())
+        throw std::runtime_error("Cannot switch if already switched");
+    original_ = character_;
+    character_ = victim;
+    victim->desc = this;
+    original_->desc = nullptr;
+}
+
+void Descriptor::do_return() {
+    if (!is_switched())
+        return;
+    character_->desc = nullptr;
+    original_->desc = this;
+    character_ = original_;
+    original_ = nullptr;
 }

--- a/src/Descriptor.hpp
+++ b/src/Descriptor.hpp
@@ -53,13 +53,13 @@ class Descriptor {
     uint16_t port_{};
     bool processing_command_{};
     DescriptorState state_{DescriptorState::GetName};
+    CHAR_DATA *character_{};
+    CHAR_DATA *original_{};
 
     [[nodiscard]] std::optional<std::string> pop_raw();
 
 public:
     Descriptor *next{};
-    CHAR_DATA *character{};
-    CHAR_DATA *original{};
 
     explicit Descriptor(uint32_t descriptor);
     ~Descriptor();
@@ -108,4 +108,15 @@ public:
 
     void processing_command(bool is_processing) noexcept { processing_command_ = is_processing; }
     [[nodiscard]] bool processing_command() const noexcept { return processing_command_; }
+
+    [[nodiscard]] CHAR_DATA *character() const noexcept { return character_; }
+    void character(CHAR_DATA *character) noexcept { character_ = character; }
+    [[nodiscard]] CHAR_DATA *original() const noexcept { return original_; }
+    // do_ prefix because switch is a C keyword
+    void do_switch(CHAR_DATA *victim);
+    // do_ prefix because return is a C keyword
+    void do_return();
+    // Return the real-life "person" player character behind this descriptor.
+    [[nodiscard]] CHAR_DATA *person() const noexcept { return original_ ? original_ : character_; }
+    [[nodiscard]] bool is_switched() const noexcept { return original_ != nullptr; }
 };

--- a/src/act_comm.cpp
+++ b/src/act_comm.cpp
@@ -98,9 +98,9 @@ void announce(const char *buf, CHAR_DATA *ch) {
     for (d = descriptor_list; d != nullptr; d = d->next) {
         CHAR_DATA *victim;
 
-        victim = d->original ? d->original : d->character;
+        victim = d->person();
 
-        if (d->is_playing() && d->character != ch && victim && can_see(victim, ch)
+        if (d->is_playing() && d->character() != ch && victim && can_see(victim, ch)
             && !IS_SET(victim->comm, COMM_NOANNOUNCE) && !IS_SET(victim->comm, COMM_QUIET)) {
             act_new(buf, victim, nullptr, ch, TO_CHAR, POS_DEAD);
         }
@@ -237,9 +237,9 @@ void do_yell(CHAR_DATA *ch, const char *argument) {
 
     act("|WYou yell '$t|W'|w", ch, argument, nullptr, TO_CHAR);
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        if (d->is_playing() && d->character != ch && d->character->in_room != nullptr
-            && d->character->in_room->area == ch->in_room->area && !IS_SET(d->character->comm, COMM_QUIET)) {
-            act("|W$n yells '$t|W'|w", ch, argument, d->character, TO_VICT);
+        if (d->is_playing() && d->character() != ch && d->character()->in_room != nullptr
+            && d->character()->in_room->area == ch->in_room->area && !IS_SET(d->character()->comm, COMM_QUIET)) {
+            act("|W$n yells '$t|W'|w", ch, argument, d->character(), TO_VICT);
         }
     }
 }

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -800,8 +800,8 @@ void do_prompt(CHAR_DATA *ch, const char *argument) {
        into a MOB.  Let's change that.... */
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            ch = ch->desc->original;
+        if (ch->desc->is_switched())
+            ch = ch->desc->original();
         else
             return;
     }
@@ -1512,8 +1512,8 @@ void do_time(CHAR_DATA *ch, const char *argument) {
     send_to_char(buf, ch);
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            ch = ch->desc->original;
+        if (ch->desc->is_switched())
+            ch = ch->desc->original();
         else
             return;
     }
@@ -1620,13 +1620,12 @@ void do_whois(CHAR_DATA *ch, const char *argument) {
     output[0] = '\0';
 
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        CHAR_DATA *wch;
         char const *class_name;
 
-        if (!d->is_playing() || !can_see(ch, d->character))
+        if (!d->is_playing() || !can_see(ch, d->character()))
             continue;
 
-        wch = (d->original != nullptr) ? d->original : d->character;
+        auto *wch = d->person();
 
         if (!can_see(ch, wch))
             continue;
@@ -1786,14 +1785,14 @@ void do_who(CHAR_DATA *ch, const char *argument) {
          * Check for match against restrictions.
          * Don't use trust as that exposes trusted mortals.
          */
-        if (!d->is_playing() || !can_see(ch, d->character))
+        if (!d->is_playing() || !can_see(ch, d->character()))
             continue;
         /* added Faramir 13/8/96 because switched imms were visible to all*/
-        if (d->original != nullptr)
-            if (!can_see(ch, d->original))
+        if (d->is_switched())
+            if (!can_see(ch, d->original()))
                 continue;
 
-        wch = (d->original != nullptr) ? d->original : d->character;
+        wch = d->person();
         if (wch->level < iLevelLower || wch->level > iLevelUpper || (fImmortalOnly && wch->level < LEVEL_HERO)
             || (fClassRestrict && !rgfClass[wch->class_num]) || (fRaceRestrict && !rgfRace[wch->race]))
             continue;
@@ -1865,7 +1864,7 @@ void do_count(CHAR_DATA *ch, const char *argument) {
     count = 0;
 
     for (d = descriptor_list; d != nullptr; d = d->next)
-        if (d->is_playing() && can_see(ch, d->character))
+        if (d->is_playing() && can_see(ch, d->character()))
             count++;
 
     max_on = UMAX(count, max_on);
@@ -2020,7 +2019,7 @@ void do_where(CHAR_DATA *ch, const char *argument) {
         send_to_char(buf, ch);
         found = false;
         for (d = descriptor_list; d; d = d->next) {
-            if (d->is_playing() && (victim = d->character) != nullptr && !IS_NPC(victim) && victim != ch
+            if (d->is_playing() && (victim = d->character()) != nullptr && !IS_NPC(victim) && victim != ch
                 && victim->in_room != nullptr && victim->in_room->area == ch->in_room->area && can_see(ch, victim)) {
                 found = true;
                 snprintf(buf, sizeof(buf), "|W%-28s|w %s\n\r", victim->name, victim->in_room->name);

--- a/src/challeng.cpp
+++ b/src/challeng.cpp
@@ -82,7 +82,7 @@ void do_challenge(CHAR_DATA *ch, const char *argument) {
         return;
     }
 
-    if (ch->desc->original != nullptr || victim->desc->original != nullptr) {
+    if (ch->desc->is_switched() || victim->desc->is_switched()) {
         send_to_char("|cYou cannot challenge with switched mobs.|w\n\r", ch);
         return;
     }

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -40,8 +40,8 @@ void do_channels(CHAR_DATA *ch, const char *argument) {
 
     /* Determine if the player is in a clan, and find which one */
     if (IS_NPC(ch)) {
-        if (ch->desc->original != nullptr)
-            OrigClan = ch->desc->original->pcdata->pcclan;
+        if (ch->desc->original() != nullptr)
+            OrigClan = ch->desc->original()->pcdata->pcclan;
         else
             OrigClan = nullptr;
     } else
@@ -126,11 +126,11 @@ void channel_command(CHAR_DATA *ch, const char *argument, int chan_flag, const c
         for (d = descriptor_list; d != nullptr; d = d->next) {
             CHAR_DATA *victim;
 
-            victim = d->original ? d->original : d->character;
+            victim = d->person();
 
-            if (d->is_playing() && d->character != ch && !IS_SET(victim->comm, chan_flag)
+            if (d->is_playing() && d->character() != ch && !IS_SET(victim->comm, chan_flag)
                 && !IS_SET(victim->comm, COMM_QUIET)) {
-                act_new(desc_other, ch, argument, d->character, TO_VICT, POS_DEAD);
+                act_new(desc_other, ch, argument, d->character(), TO_VICT, POS_DEAD);
             }
         }
     }
@@ -158,8 +158,8 @@ void do_immtalk(CHAR_DATA *ch, const char *argument) {
     if (get_trust(ch) >= 91)
         act_new(format, ch, argument, nullptr, TO_CHAR, POS_DEAD);
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        if (d->is_playing() && IS_IMMORTAL(d->character) && !IS_SET(d->character->comm, COMM_NOWIZ)) {
-            act_new(format, ch, argument, d->character, TO_VICT, POS_DEAD);
+        if (d->is_playing() && IS_IMMORTAL(d->character()) && !IS_SET(d->character()->comm, COMM_NOWIZ)) {
+            act_new(format, ch, argument, d->character(), TO_VICT, POS_DEAD);
         }
     }
 }

--- a/src/clan.cpp
+++ b/src/clan.cpp
@@ -61,8 +61,8 @@ void do_clantalk(CHAR_DATA *ch, const char *argument) {
     PCCLAN *OrigClan;
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            OrigClan = ch->desc->original->pcdata->pcclan;
+        if (ch->desc->original())
+            OrigClan = ch->desc->original()->pcdata->pcclan;
         else
             OrigClan = nullptr;
     } else
@@ -89,10 +89,9 @@ void do_clantalk(CHAR_DATA *ch, const char *argument) {
     /* Next check to see if a CLAN_HERO or CLAN_LEADER is on first */
 
     for (d = descriptor_list; (d && !candoit); d = d->next) {
-        CHAR_DATA *vix;
-        vix = d->original ? d->original : d->character;
+        CHAR_DATA *vix = d->person();
 
-        if (vix && d->character && vix->pcdata->pcclan
+        if (vix && d->character() && vix->pcdata->pcclan
             && (vix->pcdata->pcclan->clan->clanchar == OrigClan->clan->clanchar)
             && (vix->pcdata->pcclan->clanlevel >= CLAN_HERO) && !IS_SET(vix->comm, COMM_QUIET))
             candoit = 1; /* Yeah we can do it! */
@@ -122,14 +121,14 @@ void do_clantalk(CHAR_DATA *ch, const char *argument) {
     /* Right here we go - tell all members of the clan the message */
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *vix;
-        vix = d->original ? d->original : d->character;
+        vix = d->person();
 
         if ((d->is_playing()) && (vix->pcdata->pcclan)
             && (vix->pcdata->pcclan->clan->clanchar == OrigClan->clan->clanchar)
             && (vix->pcdata->pcclan->channelflags & CLANCHANNEL_ON) && !IS_SET(vix->comm, COMM_QUIET)
             /* || they're an IMM snooping the channels */) {
-            snprintf(buf, sizeof(buf), "|G<%s> %s|w\n\r", can_see(d->character, ch) ? ch->name : "Someone", argument);
-            send_to_char(buf, d->character);
+            snprintf(buf, sizeof(buf), "|G<%s> %s|w\n\r", can_see(d->character(), ch) ? ch->name : "Someone", argument);
+            send_to_char(buf, d->character());
         } /* If they can see the message */
     } /* for all descriptors */
 
@@ -336,7 +335,6 @@ void do_demote(CHAR_DATA *ch, const char *argument) { mote(ch, argument, -1); }
 void do_clanwho(CHAR_DATA *ch, const char *argument) {
     (void)argument;
     Descriptor *d;
-    CHAR_DATA *wch;
     char buf[MAX_STRING_LENGTH];
 
     if (IS_NPC(ch))
@@ -351,7 +349,7 @@ void do_clanwho(CHAR_DATA *ch, const char *argument) {
     send_to_char("|c-------------------+-------------------------------|w\n\r", ch);
     for (d = descriptor_list; d; d = d->next) {
         if (d->is_playing()) {
-            wch = (d->original) ? (d->original) : d->character;
+            auto wch = d->person();
             if ((can_see(ch, wch)) && (wch->pcdata->pcclan)
                 && (wch->pcdata->pcclan->clan->clanchar == ch->pcdata->pcclan->clan->clanchar)) {
                 snprintf(buf, sizeof(buf), "%-19s|c|||w %s\n\r", wch->name,

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -349,8 +349,8 @@ void game_loop_unix(int control) {
                          */
                         for (d = descriptor_list; d; d = d->next) {
                             if (d->channel() == p.channel) {
-                                if (d->character && d->character->level > 1)
-                                    save_char_obj(d->character);
+                                if (d->character() && d->character()->level > 1)
+                                    save_char_obj(d->character());
                                 d->clear_output_buffer();
                                 if (d->is_playing())
                                     d->state(DescriptorState::Disconnecting);
@@ -391,8 +391,8 @@ void game_loop_unix(int control) {
                         for (d = descriptor_list; d; d = d->next) {
                             if (d->channel() == p.channel) {
                                 ok = 1;
-                                if (d->character != nullptr)
-                                    d->character->timer = 0;
+                                if (d->character() != nullptr)
+                                    d->character()->timer = 0;
                                 read_from_descriptor(d, buffer, p.nExtra);
                             }
                         }
@@ -417,22 +417,23 @@ void game_loop_unix(int control) {
         for (d = descriptor_list; d; d = dNext) {
             dNext = d->next;
             d->processing_command(false);
-            if (d->character && d->character->wait > 0)
-                --d->character->wait;
+            auto *character = d->character();
+            if (character && character->wait > 0)
+                --character->wait;
             /* Waitstate the character */
-            if (d->character && d->character->wait)
+            if (character && character->wait)
                 continue;
 
             if (auto incomm = d->pop_incomm()) {
                 d->processing_command(true);
-                move_active_char_from_limbo(d->character);
+                move_active_char_from_limbo(character);
 
                 // It's possible that 'd' will be deleted as a result of any of the following operations. Be very
                 // careful.
                 if (d->is_paging())
                     d->show_next_page(*incomm);
                 else if (d->is_playing())
-                    interpret(d->character, incomm->c_str());
+                    interpret(character, incomm->c_str());
                 else
                     nanny(d, incomm->c_str());
                 // 'd' may be invalid, do no further work on it.
@@ -454,8 +455,8 @@ void game_loop_unix(int control) {
 
                 if (d->processing_command() || d->has_buffered_output()) {
                     if (!process_output(d, true)) {
-                        if (d->character != nullptr && d->character->level > 1)
-                            save_char_obj(d->character);
+                        if (d->character() != nullptr && d->character()->level > 1)
+                            save_char_obj(d->character());
                         d->clear_output_buffer();
                         close_socket(d);
                     }
@@ -535,7 +536,7 @@ void close_socket(Descriptor *dclose) {
 
     dclose->close();
 
-    if ((ch = dclose->character) != nullptr) {
+    if ((ch = dclose->character()) != nullptr) {
         do_chal_canc(ch);
         snprintf(log_buf, LOG_BUF_SIZE, "Closing link to %s.", ch->name);
         log_new(log_buf, EXTRA_WIZNET_DEBUG,
@@ -544,7 +545,7 @@ void close_socket(Descriptor *dclose) {
             act("$n has lost $s link.", ch, nullptr, nullptr, TO_ROOM);
             ch->desc = nullptr;
         } else {
-            free_char(dclose->original ? dclose->original : dclose->character);
+            free_char(dclose->person());
         }
     } else {
         /*
@@ -614,7 +615,7 @@ bool process_output(Descriptor *d, bool fPrompt) {
         CHAR_DATA *ch;
         CHAR_DATA *victim;
 
-        ch = d->character;
+        ch = d->character();
 
         /* battle prompt */
         if ((victim = ch->fighting) != nullptr) {
@@ -649,7 +650,7 @@ bool process_output(Descriptor *d, bool fPrompt) {
             d->write(buf);
         }
 
-        ch = d->original ? d->original : d->character;
+        ch = d->person();
         if (!IS_SET(ch->comm, COMM_COMPACT))
             d->write("\n\r");
 
@@ -689,7 +690,7 @@ void nanny(Descriptor *d, const char *argument) {
     while (isspace(*argument))
         argument++;
 
-    ch = d->character;
+    ch = d->character();
 
     switch (d->state()) {
 
@@ -723,7 +724,7 @@ void nanny(Descriptor *d, const char *argument) {
                  } */
 
         fOld = load_char_obj(d, char_name.c_str());
-        ch = d->character;
+        ch = d->character();
 
         if (IS_SET(ch->act, PLR_DENY)) {
             snprintf(log_buf, LOG_BUF_SIZE, "Denying access to %s@%s.", char_name.c_str(), d->host().c_str());
@@ -823,10 +824,10 @@ void nanny(Descriptor *d, const char *argument) {
         case 'Y':
             for (d_old = descriptor_list; d_old != nullptr; d_old = d_next) {
                 d_next = d_old->next;
-                if (d_old == d || d_old->character == nullptr)
+                if (d_old == d || d_old->character() == nullptr)
                     continue;
 
-                if (str_cmp(ch->name, d_old->character->name))
+                if (str_cmp(ch->name, d_old->character()->name))
                     continue;
 
                 close_socket(d_old);
@@ -834,9 +835,9 @@ void nanny(Descriptor *d, const char *argument) {
             if (check_reconnect(d, true))
                 return;
             d->write("Reconnect attempt failed.\n\rName: ");
-            if (d->character != nullptr) {
-                free_char(d->character);
-                d->character = nullptr;
+            if (d->character()) {
+                free_char(d->character());
+                d->character(nullptr);
             }
             d->state(DescriptorState::GetName);
             break;
@@ -844,9 +845,9 @@ void nanny(Descriptor *d, const char *argument) {
         case 'n':
         case 'N':
             d->write("Name: ");
-            if (d->character != nullptr) {
-                free_char(d->character);
-                d->character = nullptr;
+            if (d->character()) {
+                free_char(d->character());
+                d->character(nullptr);
             }
             d->state(DescriptorState::GetName);
             break;
@@ -869,8 +870,8 @@ void nanny(Descriptor *d, const char *argument) {
         case 'n':
         case 'N':
             d->write("Ack! Amateurs! Try typing it in properly: ");
-            free_char(d->character);
-            d->character = nullptr;
+            free_char(d->character());
+            d->character(nullptr);
             d->state(DescriptorState::GetName);
             break;
 
@@ -894,7 +895,7 @@ void nanny(Descriptor *d, const char *argument) {
             switch (*argument) {
             case 'y':
             case 'Y':
-                ch->pcdata->colour = 1;
+                ch->pcdata->colour = true;
                 send_to_char("This is a |RC|GO|BL|rO|gU|bR|cF|YU|PL |RM|GU|BD|W!\n\r", ch);
                 if (IS_HERO(ch)) {
                     do_help(ch, "imotd");
@@ -907,7 +908,7 @@ void nanny(Descriptor *d, const char *argument) {
 
             case 'n':
             case 'N':
-                ch->pcdata->colour = 0;
+                ch->pcdata->colour = false;
                 if (IS_HERO(ch)) {
                     do_help(ch, "imotd");
                     d->state(DescriptorState::ReadIMotd);
@@ -1320,13 +1321,13 @@ bool check_reconnect(Descriptor *d, bool fConn) {
     CHAR_DATA *ch;
 
     for (ch = char_list; ch != nullptr; ch = ch->next) {
-        if (!IS_NPC(ch) && (!fConn || ch->desc == nullptr) && !str_cmp(d->character->name, ch->name)) {
+        if (!IS_NPC(ch) && (!fConn || ch->desc == nullptr) && !str_cmp(d->character()->name, ch->name)) {
             if (fConn == false) {
-                free_string(d->character->pcdata->pwd);
-                d->character->pcdata->pwd = str_dup(ch->pcdata->pwd);
+                free_string(d->character()->pcdata->pwd);
+                d->character()->pcdata->pwd = str_dup(ch->pcdata->pwd);
             } else {
-                free_char(d->character);
-                d->character = ch;
+                free_char(d->character());
+                d->character(ch);
                 ch->desc = d;
                 ch->timer = 0;
                 send_to_char("Reconnecting.\n\r", ch);
@@ -1350,9 +1351,8 @@ bool check_playing(Descriptor *d, char *name) {
     Descriptor *dold;
 
     for (dold = descriptor_list; dold; dold = dold->next) {
-        if (dold != d && dold->character != nullptr && dold->state() != DescriptorState::GetName
-            && dold->state() != DescriptorState::GetOldPassword
-            && !str_cmp(name, dold->original ? dold->original->name : dold->character->name)) {
+        if (dold != d && dold->character() != nullptr && dold->state() != DescriptorState::GetName
+            && dold->state() != DescriptorState::GetOldPassword && !str_cmp(name, dold->person()->name)) {
             d->write("That character is already playing.\n\r");
             d->write("Do you wish to connect anyway (Y/N)?");
             d->state(DescriptorState::BreakConnect);
@@ -1365,13 +1365,10 @@ bool check_playing(Descriptor *d, char *name) {
 
 // Write to one char.
 void send_to_char(std::string_view txt, CHAR_DATA *ch) {
-    if (txt.empty() || ch->desc == nullptr)
+    if (txt.empty() || ch->desc == nullptr || !ch->desc->person())
         return;
-    auto colour = (!IS_NPC(ch) && (ch->pcdata->colour))
-                  || ((IS_NPC(ch) && (ch->desc->original != nullptr) /* paranoia factor */
-                       && (ch->desc->original->pcdata->colour)));
 
-    ch->desc->write(colourise_mud_string(colour, txt));
+    ch->desc->write(colourise_mud_string(ch->desc->person()->pcdata->colour, txt));
 }
 
 /*
@@ -1536,9 +1533,9 @@ void act_new(const char *format, CHAR_DATA *ch, const void *arg1, const void *ar
             Descriptor *d;
 
             for (d = descriptor_list; d != nullptr; d = d->next) {
-                if (d->character != nullptr && d->character->in_room != nullptr && d->character->in_room->vnum == 1222
-                    && IS_AWAKE(d->character))
-                    send_to_char(buf, d->character);
+                if (d->character() && d->character()->in_room != nullptr && d->character()->in_room->vnum == 1222
+                    && IS_AWAKE(d->character()))
+                    send_to_char(buf, d->character());
             }
         }
     }
@@ -1554,7 +1551,7 @@ void show_prompt(Descriptor *d, char *prompt) {
     const char *i;
     int bufspace = 255; /* Counter of space left in buf[] */
 
-    ch = d->character;
+    ch = d->character();
     /*
      * Discard null and zero-length prompts.
      */
@@ -1563,8 +1560,8 @@ void show_prompt(Descriptor *d, char *prompt) {
         send_to_char("|p", ch);
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            ch_prefix = ch->desc->original;
+        if (ch->desc->original())
+            ch_prefix = ch->desc->original();
     } else
         ch_prefix = ch;
 

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -470,8 +470,8 @@ int get_trust(CHAR_DATA *ch) {
         return 0;
     }
 
-    if (ch->desc != nullptr && ch->desc->original != nullptr)
-        ch = ch->desc->original;
+    if (ch->desc != nullptr && ch->desc->is_switched())
+        ch = ch->desc->original();
 
     if (ch->trust != 0)
         return ch->trust;
@@ -1400,9 +1400,8 @@ void extract_char(CHAR_DATA *ch, bool fPull) {
     if (IS_NPC(ch))
         --ch->pIndexData->count;
 
-    if (ch->desc != nullptr && ch->desc->original != nullptr) {
-        char empty[] = "";
-        do_return(ch, empty);
+    if (ch->desc != nullptr && ch->desc->is_switched()) {
+        do_return(ch, "");
     }
 
     for (wch = char_list; wch != nullptr; wch = wch->next) {
@@ -1429,7 +1428,7 @@ void extract_char(CHAR_DATA *ch, bool fPull) {
     }
 
     if (ch->desc)
-        ch->desc->character = nullptr;
+        ch->desc->character(nullptr);
     free_char(ch);
 }
 

--- a/src/interp.cpp
+++ b/src/interp.cpp
@@ -383,8 +383,8 @@ static const char *apply_prefix(char *buf, CHAR_DATA *ch, const char *command) {
 
     /* Unswitched MOBs don't have prefixes.  If we're switched, get the player's prefix. */
     if (IS_NPC(ch)) {
-        if (ch->desc && ch->desc->original)
-            pc_prefix = ch->desc->original->pcdata->prefix;
+        if (ch->desc && ch->desc->original())
+            pc_prefix = ch->desc->original()->pcdata->prefix;
         else
             return command;
     } else
@@ -465,8 +465,8 @@ void interpret(CHAR_DATA *ch, const char *argument) {
         int level = (cmd->level >= 91) ? (cmd->level) : 0;
         if (!IS_NPC(ch) && (IS_SET(ch->act, PLR_WIZINVIS) || IS_SET(ch->act, PLR_PROWL)))
             level = UMAX(level, get_trust(ch));
-        if (IS_NPC(ch) && ch->desc && ch->desc->original) {
-            snprintf(log_buf, LOG_BUF_SIZE, "Log %s (as '%s'): %s", ch->desc->original->name, ch->name, logline);
+        if (IS_NPC(ch) && ch->desc && ch->desc->original()) {
+            snprintf(log_buf, LOG_BUF_SIZE, "Log %s (as '%s'): %s", ch->desc->original()->name, ch->name, logline);
         } else {
             snprintf(log_buf, LOG_BUF_SIZE, "Log %s: %s", ch->name, logline);
         }

--- a/src/mob_commands.cpp
+++ b/src/mob_commands.cpp
@@ -520,10 +520,10 @@ void do_mptransfer(CHAR_DATA *ch, const char *argument) {
 
     if (!str_cmp(arg1, "all")) {
         for (d = descriptor_list; d != nullptr; d = d->next) {
-            if (d->is_playing() && d->character != ch && d->character->in_room != nullptr
-                && can_see(ch, d->character)) {
+            if (d->is_playing() && d->character() != ch && d->character()->in_room != nullptr
+                && can_see(ch, d->character())) {
                 char buf[MAX_STRING_LENGTH];
-                snprintf(buf, sizeof(buf), "%s %s", d->character->name, arg2);
+                snprintf(buf, sizeof(buf), "%s %s", d->character()->name, arg2);
                 do_transfer(ch, buf);
             }
         }

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -631,7 +631,7 @@ void do_news_delete(CHAR_DATA *ch, const char *argument) {
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *person;
         if (d->is_playing()) {
-            person = d->original ? d->original : d->character; // Find the corresponding person assoc'd with d
+            person = d->person(); // Find the corresponding person assoc'd with d
             if ((person != nullptr) && // Do they exist?
                 (person->article == art)) // Are they looking at this article?
                 move_to_next_unread(person); // If so - move them on
@@ -658,7 +658,7 @@ void do_news_delete(CHAR_DATA *ch, const char *argument) {
         for (d = descriptor_list; d; d = d->next) {
             CHAR_DATA *person;
             if (d->is_playing()) {
-                person = d->original ? d->original : d->character; // Find the corresponding person assoc'd with d
+                person = d->person(); // Find the corresponding person assoc'd with d
                 if ((person != nullptr) && // Do they exist?
                     (person->thread == chthread)) { // Are they looking at this thread?
                     person->article = nullptr;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -341,8 +341,8 @@ void note_announce(CHAR_DATA *chsender, NOTE_DATA *note) {
     }
     for (d = descriptor_list; d; d = d->next) {
         CHAR_DATA *chtarg;
-        chtarg = d->original ? d->original : d->character;
-        if (d->is_playing() && d->character != chsender && chtarg && !IS_SET(chtarg->comm, COMM_NOANNOUNCE)
+        chtarg = d->person();
+        if (d->is_playing() && d->character() != chsender && chtarg && !IS_SET(chtarg->comm, COMM_NOANNOUNCE)
             && !IS_SET(chtarg->comm, COMM_QUIET) && is_note_to(chtarg, note)) {
             send_to_char("The Spirit of Hermes announces the arrival of a new note.\n\r", chtarg);
         }

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -79,8 +79,8 @@ void save_char_obj(CHAR_DATA *ch) {
     if (IS_NPC(ch))
         return;
 
-    if (ch->desc != nullptr && ch->desc->original != nullptr)
-        ch = ch->desc->original;
+    if (ch->desc != nullptr && ch->desc->is_switched())
+        ch = ch->desc->original();
 
     /* create god log */
     if (IS_IMMORTAL(ch) || ch->level >= LEVEL_IMMORTAL) {
@@ -456,7 +456,7 @@ bool load_char_obj(Descriptor *d, const char *name) {
     }
     *ch->pcdata = pcdata_zero;
 
-    d->character = ch;
+    d->character(ch);
     ch->desc = d;
     ch->name = str_dup(name);
     ch->version = 0;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -517,8 +517,8 @@ void weather_update() {
 
     if (buf[0] != '\0') {
         for (d = descriptor_list; d != nullptr; d = d->next) {
-            if (d->is_playing() && IS_OUTSIDE(d->character) && IS_AWAKE(d->character))
-                send_to_char(buf, d->character);
+            if (d->is_playing() && IS_OUTSIDE(d->character()) && IS_AWAKE(d->character()))
+                send_to_char(buf, d->character());
         }
     }
 }

--- a/src/wiznet.cpp
+++ b/src/wiznet.cpp
@@ -77,11 +77,11 @@ void log_new(const char *str, int loglevel, int level) {
         level = UMAX(level, 96); /* Prevent non-SOCK ppl finding out sin_addrs */
 
     for (d = descriptor_list; d; d = d->next) {
-        CHAR_DATA *ch = d->original ? d->original : d->character;
+        CHAR_DATA *ch = d->person();
         if ((!d->is_playing()) || (ch == nullptr) || (IS_NPC(ch)) || !is_set_extra(ch, EXTRA_WIZNET_ON)
             || !is_set_extra(ch, loglevel) || (get_trust(ch) < level))
             continue;
-        send_to_char(buf, d->character);
+        send_to_char(buf, d->character());
     }
 }
 

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -231,8 +231,8 @@ void do_prefix(CHAR_DATA *ch, const char *argument) {
         prefix.resize(MAX_STRING_LENGTH - 1);
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            ch_prefix = ch->desc->original;
+        if (ch->desc->original())
+            ch_prefix = ch->desc->original();
         else
             return;
     } else
@@ -265,8 +265,8 @@ void do_timezone(CHAR_DATA *ch, const char *argument) {
     char buf[64];
 
     if (IS_NPC(ch)) {
-        if (ch->desc->original)
-            ch_owner = ch->desc->original;
+        if (ch->desc->original())
+            ch_owner = ch->desc->original();
         else
             return;
     } else
@@ -298,7 +298,7 @@ int get_skill_level(CHAR_DATA *ch, int gsn) {
     if (IS_NPC(ch)) {
 
         if (ch->desc) { /* Is this a switched IMM? */
-            if ((ch = ch->desc->original) == nullptr) {
+            if ((ch = ch->desc->original()) == nullptr) {
                 return 1;
             }
         } else { /* A genuine NPC */
@@ -690,10 +690,7 @@ void web_who() {
     fprintf(fp, "<b><TR><TD>Level</TD> <TD>Race</TD> <TD>Class</TD>  <TD>Who</TD></TR></b>\n");
 
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        CHAR_DATA *wch;
-
-        wch = (d->original != nullptr) ? d->original : d->character;
-
+        auto wch = d->person();
         if (!d->is_playing() || !web_see(wch))
             continue;
         fprintf(fp, "<TR><TD>%d</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD>\n", wch->level,
@@ -776,13 +773,10 @@ void tip_players() {
     }
     snprintf(buf, sizeof(buf), "|WTip: %s|w\n\r", tip_current->tip);
     for (d = descriptor_list; d != nullptr; d = d->next) {
-        CHAR_DATA *ch;
-
-        ch = (d->original != nullptr) ? d->original : d->character;
-
         if (!d->is_playing())
             continue;
 
+        CHAR_DATA *ch = d->person();
         if (is_set_extra(ch, EXTRA_TIP_WIZARD)) {
             send_to_char(buf, ch);
         }


### PR DESCRIPTION
Some subleties here, mainly around trying to unify and fix up some weird uses of "original" vs " character". See what you think. A lot is purely mechanical, but I extracted "person()" to mean "the actual person behind this descriptor" and hopefully used it correctly.