### PR TITLE
Add a "player()" function.

### DIFF
--- a/src/CHAR_DATA.hpp
+++ b/src/CHAR_DATA.hpp
@@ -132,6 +132,14 @@ struct CHAR_DATA {
     // Retrieve a character's trusted level for permission checking.
     [[nodiscard]] int get_trust() const;
 
+    // Returns the PC character controlling this character,or nullptr if not controlled by a pc.
+    // That is:
+    // * For a player: return this
+    // * For an NPC controlled by a switched IMM, return that IMM
+    // * For a normal NPC, return null.
+    [[nodiscard]] const CHAR_DATA *player() const { return desc ? desc->person() : nullptr; }
+    [[nodiscard]] CHAR_DATA *player() { return desc ? desc->person() : nullptr; }
+
     [[nodiscard]] bool has_holylight() const;
     [[nodiscard]] bool is_immortal() const;
 

--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -801,13 +801,8 @@ void do_prompt(CHAR_DATA *ch, const char *argument) {
 
     /* PCFN 24-05-97  Oh dear - it seems that you can't set prompt while switched
        into a MOB.  Let's change that.... */
-
-    if (IS_NPC(ch)) {
-        if (ch->desc->is_switched())
-            ch = ch->desc->original();
-        else
-            return;
-    }
+    if (ch = ch->player(); !ch)
+        return;
 
     if (str_cmp(argument, "off") == 0) {
         send_to_char("You will no longer see prompts.\n\r", ch);
@@ -1475,12 +1470,8 @@ void do_time(CHAR_DATA *ch, const char *argument) {
                      time_info.describe(), secs_only(boot_time), secs_only(current_time)),
                  ch);
 
-    if (IS_NPC(ch)) {
-        if (ch->desc->is_switched())
-            ch = ch->desc->original();
-        else
-            return;
-    }
+    if (ch = ch->player(); !ch)
+        return;
 
     // TODO(#95) now we have an actual time library we can replace this with a timezone and format accordingly.
     if (ch->pcdata->houroffset || ch->pcdata->minoffset) {

--- a/src/channels.cpp
+++ b/src/channels.cpp
@@ -41,13 +41,7 @@ void do_channels(CHAR_DATA *ch, const char *argument) {
     print_channel_status(ch, "shout", ch->comm, COMM_NOSHOUT);
 
     /* Determine if the player is in a clan, and find which one */
-    if (IS_NPC(ch)) {
-        if (ch->desc->original() != nullptr)
-            OrigClan = ch->desc->original()->pcdata->pcclan;
-        else
-            OrigClan = nullptr;
-    } else
-        OrigClan = ch->pcdata->pcclan;
+    OrigClan = ch->player() ? ch->player()->pcdata->pcclan : nullptr;
 
     if (OrigClan) {
         print_channel_status(ch, "clan channel", (OrigClan->channelflags) ^ CLANCHANNEL_ON, CLANCHANNEL_ON);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -1399,7 +1399,6 @@ void show_prompt(Descriptor *d, char *prompt) {
     char buf[256]; /* this is actually sent to the ch */
     char buf2[64];
     CHAR_DATA *ch;
-    CHAR_DATA *ch_prefix = nullptr; /* Needed for prefix in prompt with switched MOB */
     char *point;
     char *str;
     const char *i;
@@ -1413,11 +1412,7 @@ void show_prompt(Descriptor *d, char *prompt) {
     if (!IS_NPC(ch) && (ch->pcdata->colour))
         send_to_char("|p", ch);
 
-    if (IS_NPC(ch)) {
-        if (ch->desc->original())
-            ch_prefix = ch->desc->original();
-    } else
-        ch_prefix = ch;
+    auto ch_prefix = ch->player();
 
     if (prompt == nullptr || prompt[0] == '\0') {
         snprintf(buf, sizeof(buf), "<%d/%dhp %d/%dm %dmv> |w", ch->hit, ch->max_hit, ch->mana, ch->max_mana, ch->move);

--- a/src/interp.cpp
+++ b/src/interp.cpp
@@ -386,30 +386,27 @@ void interp_initialise() {
 }
 
 static const char *apply_prefix(char *buf, CHAR_DATA *ch, const char *command) {
-    char *pc_prefix = nullptr;
-
-    /* Unswitched MOBs don't have prefixes.  If we're switched, get the player's prefix. */
-    if (IS_NPC(ch)) {
-        if (ch->desc && ch->desc->original())
-            pc_prefix = ch->desc->original()->pcdata->prefix;
-        else
-            return command;
-    } else
-        pc_prefix = ch->pcdata->prefix;
+    // Unswitched MOBs don't have prefixes.  If we're switched, get the player's prefix.
+    auto player = ch->player();
+    if (!player)
+        return command;
 
     if (0 == strcmp(command, "prefix")) {
         return command;
-    } else if (command[0] == '\\') {
-        if (command[1] == '\\') {
-            send_to_char(pc_prefix[0] ? "(prefix removed)\n\r" : "(no prefix to remove)\n\r", ch);
-            pc_prefix[0] = '\0';
-            command++; /* skip the \ */
-        }
-        command++; /* skip the \ */
-        return command;
     } else {
-        snprintf(buf, MAX_INPUT_LENGTH, "%s%s", pc_prefix, command);
-        return buf;
+        auto &pc_data = player->pcdata;
+        if (command[0] == '\\') {
+            if (command[1] == '\\') {
+                send_to_char(pc_data->prefix ? "(prefix removed)\n\r" : "(no prefix to remove)\n\r", ch);
+                pc_data->prefix[0] = '\0';
+                command++; /* skip the \ */
+            }
+            command++; /* skip the \ */
+            return command;
+        } else {
+            snprintf(buf, MAX_INPUT_LENGTH, "%s%s", pc_data->prefix, command);
+            return buf;
+        }
     }
 }
 

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -80,11 +80,8 @@ void save_char_obj(CHAR_DATA *ch) {
     char buf[MAX_STRING_LENGTH];
     FILE *fp;
 
-    if (IS_NPC(ch))
+    if (ch = ch->player(); !ch)
         return;
-
-    if (ch->desc != nullptr && ch->desc->is_switched())
-        ch = ch->desc->original();
 
     /* create god log */
     if (IS_IMMORTAL(ch) || ch->level >= LEVEL_IMMORTAL) {

--- a/src/xania.cpp
+++ b/src/xania.cpp
@@ -224,69 +224,43 @@ void set_prefix(CHAR_DATA *ch, const char *prefix) {
 
 /* do_prefix added 19-05-97 PCFN */
 void do_prefix(CHAR_DATA *ch, const char *argument) {
-    CHAR_DATA *ch_prefix = nullptr;
-    char ch_buffer[MAX_STRING_LENGTH];
+    if (ch = ch->player(); !ch)
+        return;
 
     auto prefix = smash_tilde(argument);
-
     if (prefix.length() > (MAX_STRING_LENGTH - 1))
         prefix.resize(MAX_STRING_LENGTH - 1);
 
-    if (IS_NPC(ch)) {
-        if (ch->desc->original())
-            ch_prefix = ch->desc->original();
-        else
-            return;
-    } else
-        ch_prefix = ch;
-
-    /* ch_prefix is the character, or the character who is switched into the MOB
-       otherwise it's nullptr */
-
-    if (ch_prefix == nullptr)
-        return;
-
     if (prefix.empty()) {
-        if (ch_prefix->pcdata->prefix[0] == '\0') {
-            snprintf(ch_buffer, sizeof(ch_buffer), "No prefix to remove.\n\r");
+        if (ch->pcdata->prefix[0] == '\0') {
+            ch->send_to("No prefix to remove.\n\r");
         } else {
-            snprintf(ch_buffer, sizeof(ch_buffer), "Prefix removed.\n\r");
+            ch->send_to("Prefix removed.\n\r");
         }
+        return;
     }
 
-    set_prefix(ch_prefix, prefix.c_str());
-    if (ch_prefix->pcdata->prefix[0] != '\0')
-        snprintf(ch_buffer, sizeof(ch_buffer), "Prefix set to \"%s\"\n\r", ch_prefix->pcdata->prefix);
-
-    send_to_char(ch_buffer, ch);
+    set_prefix(ch, prefix.c_str());
+    ch->send_to("Prefix set to \"{}\".\n\r"_format(ch->pcdata->prefix));
 }
 
 /* do_timezone added PCFN 24-05-97 */
 void do_timezone(CHAR_DATA *ch, const char *argument) {
-    CHAR_DATA *ch_owner = nullptr;
-    char buf[64];
-
-    if (IS_NPC(ch)) {
-        if (ch->desc->original())
-            ch_owner = ch->desc->original();
-        else
-            return;
-    } else
-        ch_owner = ch;
+    if (ch = ch->player(); !ch)
+        return;
 
     if (argument[0] == '\0') {
-        if (ch_owner->pcdata->minoffset == 0 && ch_owner->pcdata->houroffset == 0)
-            send_to_char("British time is already being used\n\r", ch_owner);
+        if (ch->pcdata->minoffset == 0 && ch->pcdata->houroffset == 0)
+            ch->send_to("British time is already being used\n\r");
         else {
-            send_to_char("British time will be used\n\r", ch_owner);
-            ch_owner->pcdata->minoffset = 0;
-            ch_owner->pcdata->houroffset = 0;
+            ch->send_to("British time will be used\n\r");
+            ch->pcdata->minoffset = 0;
+            ch->pcdata->houroffset = 0;
         }
     } else {
-        sscanf(argument, "%d:%d", (int *)&(ch_owner->pcdata->houroffset), (int *)&(ch_owner->pcdata->minoffset));
-        snprintf(buf, sizeof(buf), "Time will now be displayed %d:%02d from GMT\n\r", ch_owner->pcdata->houroffset,
-                 ch_owner->pcdata->minoffset);
-        send_to_char(buf, ch_owner);
+        sscanf(argument, "%hd:%hd", &ch->pcdata->houroffset, &ch->pcdata->minoffset);
+        ch->send_to(
+            "Time will now be displayed %d:%02d from GMT\n\r"_format(ch->pcdata->houroffset, ch->pcdata->minoffset));
     }
 }
 
@@ -297,16 +271,8 @@ void do_timezone(CHAR_DATA *ch, const char *argument) {
 int get_skill_level(const CHAR_DATA *ch, int gsn) {
     int level = 0, bonus;
 
-    if (IS_NPC(ch)) {
-
-        if (ch->desc) { /* Is this a switched IMM? */
-            if ((ch = ch->desc->original()) == nullptr) {
-                return 1;
-            }
-        } else { /* A genuine NPC */
-            return 1;
-        }
-    }
+    if (ch = ch->player(); !ch)
+        return 1;
 
     /* First we work out which level they'd get it at because of their class */
 


### PR DESCRIPTION
Many of the newer routines handled switched mobs by checking multiple
conditions. This extracts a "player()" function on the CHAR_DATA,
which returns the CHAR_DATA of the "real player" behind a character,
be they the character themselves, a controlling switched IMM, or
nullptr for a genuine, uncontrolled-by-player-character NPC.

I think this is equivalent to the earlier code and reduces complexity.
I wonder if the command interpreter can subsume this at some point,
with commands tagged as "no, this has to occur on the actual PC, not
the switched mob they might be controlling", to save further, though
that might be unobvious.