### PR TITLE
Handle prompting consistently.

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -175,8 +175,8 @@ std::string_view wound_for(int percent) {
     if (percent >= 15)
         return "looks pretty hurt.";
     if (percent >= 0)
-        return "is in awful condition.";
-    return "is bleeding to death.";
+        return "is in |rawful condition|w.";
+    return "is |Rbleeding to death|w.";
 }
 }
 


### PR DESCRIPTION
* Use decriptor writes only in the output routines, instead of funky reacharound back to chars
* Handle colourisation of prompts and battle status in the same way.
* Reinstate colour in the battle status.