### PR TITLE
Initial work on a vector of "safe to remove" things

### DIFF
--- a/src/AFFECT_DATA.hpp
+++ b/src/AFFECT_DATA.hpp
@@ -7,7 +7,6 @@
 
 // A single effect that affects an object or character.
 struct AFFECT_DATA {
-    AFFECT_DATA *next{};
     sh_int type{};
     sh_int level{};
     sh_int duration{};

--- a/src/AffectList.cpp
+++ b/src/AffectList.cpp
@@ -5,32 +5,21 @@
 #include <range/v3/iterator/operations.hpp>
 
 AFFECT_DATA &AffectList::add(const AFFECT_DATA &aff) {
-    auto new_aff = new AFFECT_DATA{aff};
-    new_aff->next = first_;
-    first_ = new_aff;
-    return *new_aff;
+    data_.insert(data_.begin(), aff);
+    return data_.front();
 }
 
 void AffectList::remove(const AFFECT_DATA &aff) {
-    if (&aff == first_) {
-        first_ = aff.next;
-    } else {
-        AFFECT_DATA *prev;
-
-        for (prev = first_; prev != nullptr; prev = prev->next) {
-            if (prev->next == &aff) {
-                prev->next = aff.next;
-                break;
-            }
-        }
-
-        if (prev == nullptr) {
-            bug("Affect_remove: cannot find paf.");
-            // TODO may leak
-            return;
-        }
+    auto index = &aff - data_.data();
+    if (index < 0 || static_cast<size_t>(index) > data_.size()) {
+        bug("Affect_remove: cannot find paf.");
+        return;
     }
-    delete &aff; // UGH
+    data_.erase(std::next(begin(), index));
+    for (auto *next_ptr : next_ptrs_) {
+        if (*next_ptr > static_cast<size_t>(index))
+            --*next_ptr;
+    }
 }
 
 AFFECT_DATA *AffectList::find_by_skill(int skill_number) {
@@ -45,9 +34,6 @@ const AFFECT_DATA *AffectList::find_by_skill(int skill_number) const {
     return nullptr;
 }
 
-size_t AffectList::size() const noexcept { return ranges::distance(*this); }
+size_t AffectList::size() const noexcept { return data_.size(); }
 
-void AffectList::clear() {
-    while (first_)
-        remove(*first_);
-}
+void AffectList::clear() { data_.clear(); }

--- a/src/AffectList.hpp
+++ b/src/AffectList.hpp
@@ -1,38 +1,50 @@
 #pragma once
 
 #include "AFFECT_DATA.hpp"
-#include "GenericListIter.hpp"
+
+#include <vector>
 
 class AffectList {
-    AFFECT_DATA *first_{};
+    std::vector<AFFECT_DATA> data_;
+
+    // The next_ptrs tracks a list of all the "next index" variables on the call stack. If an element is removed that
+    // is strictly less than any of the "next index" variables, then those variables need to be decremented to account
+    // for the removed element.
+    std::vector<size_t *> next_ptrs_;
+    struct NextIndex {
+        AffectList &list;
+        size_t next{};
+        explicit NextIndex(AffectList &list) : list(list) { list.next_ptrs_.emplace_back(&next); }
+        ~NextIndex() { list.next_ptrs_.pop_back(); }
+    };
 
 public:
     AFFECT_DATA &add(const AFFECT_DATA &aff);
     void remove(const AFFECT_DATA &aff);
 
     void clear();
-    [[nodiscard]] bool empty() const noexcept { return !first_; }
+    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
 
     [[nodiscard]] AFFECT_DATA *find_by_skill(int skill_number);
     [[nodiscard]] const AFFECT_DATA *find_by_skill(int skill_number) const;
 
     [[nodiscard]] size_t size() const noexcept;
-    [[nodiscard]] AFFECT_DATA &front() { return *first_; }
-    [[nodiscard]] const AFFECT_DATA &front() const { return *first_; }
+    [[nodiscard]] AFFECT_DATA &front() { return data_.front(); }
+    [[nodiscard]] const AFFECT_DATA &front() const { return data_.front(); }
 
     template <typename Func>
     void modification_safe_for_each(const Func &func) {
-        AFFECT_DATA *next;
-        for (auto *paf = first_; paf; paf = next) {
-            next = paf->next;
-            func(*paf);
+        NextIndex idx{*this};
+        for (size_t index = idx.next; index < data_.size(); index = idx.next) {
+            idx.next++;
+            func(data_[index]);
         }
     }
 
-    [[nodiscard]] auto begin() { return GenericListIter<AFFECT_DATA>(first_); }
-    [[nodiscard]] auto end() { return GenericListIter<AFFECT_DATA>(); }
-    [[nodiscard]] auto begin() const { return GenericListIter<const AFFECT_DATA>(first_); }
-    [[nodiscard]] auto end() const { return GenericListIter<const AFFECT_DATA>(); }
+    [[nodiscard]] auto begin() { return data_.begin(); }
+    [[nodiscard]] auto end() { return data_.end(); }
+    [[nodiscard]] auto begin() const { return data_.begin(); }
+    [[nodiscard]] auto end() const { return data_.end(); }
 };
 
 inline auto begin(AffectList &al) { return al.begin(); }

--- a/src/test/AFFECT_DATATest.cpp
+++ b/src/test/AFFECT_DATATest.cpp
@@ -17,7 +17,6 @@ TEST_CASE("AFFECT_DATA") {
 
     SECTION("should start with sane defaults") {
         AFFECT_DATA af;
-        CHECK(af.next == nullptr);
         CHECK(af.type == 0);
         CHECK(af.level == 0);
         CHECK(af.duration == 0);
@@ -90,13 +89,13 @@ TEST_CASE("AFFECT_DATA") {
     }
 
     SECTION("should identify skills") {
-        CHECK(!AFFECT_DATA{nullptr, gsn_blindness}.is_skill());
-        CHECK(AFFECT_DATA{nullptr, gsn_sneak}.is_skill());
-        CHECK(AFFECT_DATA{nullptr, gsn_ride}.is_skill());
+        CHECK(!AFFECT_DATA{gsn_blindness}.is_skill());
+        CHECK(AFFECT_DATA{gsn_sneak}.is_skill());
+        CHECK(AFFECT_DATA{gsn_ride}.is_skill());
     }
 
     SECTION("should describe effects") {
-        auto spell = AFFECT_DATA{nullptr, -1, 33, 22, AffectLocation::Wis, 1, AFF_HASTE};
+        auto spell = AFFECT_DATA{-1, 33, 22, AffectLocation::Wis, 1, AFF_HASTE};
         SECTION("for items") {
             CHECK(spell.describe_item_effect(false) == "wisdom by 1");
             CHECK(spell.describe_item_effect(true) == "wisdom by 1 with bits haste, level 33");
@@ -107,7 +106,7 @@ TEST_CASE("AFFECT_DATA") {
                 CHECK(spell.describe_char_effect(true) == "wisdom by 1 for 22 hours with bits haste, level 33");
             }
             SECTION("skills") {
-                auto skill = AFFECT_DATA{nullptr, gsn_sneak, 80, 0, AffectLocation::None, 0, AFF_SNEAK};
+                auto skill = AFFECT_DATA{gsn_sneak, 80, 0, AffectLocation::None, 0, AFF_SNEAK};
                 CHECK(skill.describe_char_effect(false) == "none by 0");
                 CHECK(skill.describe_char_effect(true) == "none by 0 with bits sneak, level 80");
             }

--- a/src/test/AffectListTest.cpp
+++ b/src/test/AffectListTest.cpp
@@ -1,0 +1,48 @@
+#include "AffectList.hpp"
+
+#include <catch2/catch.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/transform.hpp>
+
+namespace {
+using vi = std::vector<int>;
+vi to_vi(const AffectList &list) {
+    return list | ranges::view::transform([](auto &ad) { return ad.type; }) | ranges::to<std::vector<int>>;
+}
+
+}
+
+TEST_CASE("Affect list") {
+    AffectList list;
+    SECTION("starts empty") { CHECK(list.empty()); }
+    SECTION("adds to the front") {
+        list.add(AFFECT_DATA{1});
+        list.add(AFFECT_DATA{2});
+        list.add(AFFECT_DATA{3});
+        CHECK(!list.empty());
+        CHECK(list.size() == 3);
+        CHECK(to_vi(list) == vi{3, 2, 1});
+        SECTION("and can remove them") {
+            SECTION("from the front") {
+                list.remove(list.front());
+                CHECK(to_vi(list) == vi{2, 1});
+                list.remove(list.front());
+                CHECK(to_vi(list) == vi{1});
+                list.remove(list.front());
+                CHECK(to_vi(list).empty());
+            }
+            SECTION("from the middle") {
+                list.remove(*std::next(list.begin()));
+                CHECK(to_vi(list) == vi{3, 1});
+            }
+            SECTION("from the end") {
+                list.remove(*std::next(list.begin(), 2));
+                CHECK(to_vi(list) == vi{3, 2});
+            }
+        }
+        SECTION("can remove them while iterating") {
+            list.modification_safe_for_each([&list](const AFFECT_DATA &af) { list.remove(af); });
+            CHECK(list.empty());
+        }
+    }
+}


### PR DESCRIPTION
Tested, and working. But I wonder if this is the right approach:

* a vector is cool but maybe a list is great after all?
* supports arbitrary nesting of safe_iteration, which seems overkill
* supports removal of items other than the "currently iterated over"
  (this is untested as the old code path didn't support it).
* doesn't support "clear" while safe iterating
* "safe iteration" is a modification_safe_for_each, not general-purpose
  iteration. Should _probably_ support any kind of iteration.

I'm thinking this pattern is common enough that we should come up with a
decent solution that "just works" in all cases. I would like to be able
to write:

```cpp
ranges::for_each(container, [](auto &elem) { if (elem.bad()) container.remove(elem); }
```

and have it "Just Work". Maybe that's overkill, it's certainly atypical C++ code.

The old code is a bit split-brained about whether it used `it = it->next` or `it = it_next`,
and the old code also didn't support multiple removals during iteration (see
for example #182).