### PR TITLE
Change signal handling when a debugger is attached.

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -302,7 +302,6 @@ void game_loop_unix(Fd control) {
          * Poll all active descriptors.
          */
         FD_ZERO(&in_set);
-        FD_ZERO(&in_set);
         FD_ZERO(&out_set);
         FD_ZERO(&exc_set);
         FD_SET(control.number(), &in_set);


### PR DESCRIPTION
Continue to block SIGINT and handle it as a shutdown, but if a
debugger is detected, instead raise a SIGTRAP to hit a breakpoint.

Closes #191 (I think). I tested it with running under `gdb`, and with `gdb -p` and it did the Right Thing™ as far as I could tell, but I didn't test under vscode (sorry; I was lazy...)

Would you mind checking to see if this fixes things for you, @snellers? Thanks!