### PR TITLE
logrotate uses copytruncate mode as the stderr/stdout never get close…

### DIFF
--- a/infra/scripts/xania.logrotate
+++ b/infra/scripts/xania.logrotate
@@ -2,5 +2,7 @@
 /home/xania/data/log/doorman.log
 {
     daily
+    size 1M
+    copytruncate
     rotate 60
 }


### PR DESCRIPTION
…d, and only rotate if the log file gets large enough. Resolves #63