### PR TITLE
pfu player file upgrade utility and prepare-pfiles.sh upgrade script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,42 @@
     "configurations": [
 
 
-
-
+    {
+        "name": "(gdb) pfu",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/cmake-build-debug/bin/pfu",
+        "args": [],
+        "stopAtEntry": false,
+        "cwd": "${workspaceFolder}",
+        "environment": [
+            { 
+                "name" : "MUD_DATA_DIR",
+                "value" : "${env:HOME}/tmp/pfiles"
+            },
+            { 
+                "name" : "MUD_AREA_DIR",
+                "value" : "${workspaceFolder}/install/area"
+            },
+            { 
+                "name" : "MUD_HTML_DIR",
+                "value" : "${workspaceFolder}/install/html"
+            },
+            {
+                "name" : "MUD_PORT",
+                "value" : "9000"
+            }
+        ],
+        "externalConsole": false,
+        "MIMode": "gdb",
+        "setupCommands": [
+            {
+                "description": "Enable pretty-printing for gdb",
+                "text": "-enable-pretty-printing",
+                "ignoreFailures": true
+            }
+        ]
+    },
         {
             "name": "(gdb) xania_test",
             "type": "cppdbg",
@@ -45,7 +79,30 @@
                     "ignoreFailures": true
                 }
             ]
-        },        
+        },
+        {
+            "name": "(gdb) apps_test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/cmake-build-debug/bin/apps_test",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [ 
+                { "name" : "MELD_ON_DIFF",
+                  "value" : "1"
+                }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
         {
             "name": "Debug Xania",
             "type": "cppdbg",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "cmake.configureOnOpen": true,
     "cmake.buildDirectory" : "cmake-build-debug",
-    "cmake.installPrefix" : "${workspaceFolder}/install"
+    "cmake.installPrefix" : "${workspaceFolder}/install",
+    "editor.acceptSuggestionOnEnter": "off"
 }

--- a/area/rom.are
+++ b/area/rom.are
@@ -121,7 +121,7 @@ Apr 16:
 automatically loots non-droppable or non-removeable objects.
 *   Objects marked as 'no drop' can longer have their 'no drop' status 
 removed by the 'remove curse' spell. The 'damnation' spell no longer sets
-the 'no drop' status too, but it still weapons immune from disarm in combat!
+the 'no drop' status too, but it still makes weapons immune from disarm!
 
 Apr 15: Some special and/or powerful objects are now regarded by the Gods
 as unique. You can only possess one instance of a unique item at a time.

--- a/infra/scripts/pfile-upgrade-lib.sh
+++ b/infra/scripts/pfile-upgrade-lib.sh
@@ -1,0 +1,18 @@
+# Common setup needed by the pfile upgrade scripts.
+set -euo pipefail
+
+if [ $# != 1 ]; then
+    echo "Usage: $0 [release number]"
+    exit 1
+fi
+if [[ $LOGNAME == "xania" ]]; then
+    . ~/xania/infra/scripts/mud-settings-prod.sh
+    PATH=~/releases/current/bin:$PATH
+else
+    . mud-settings-dev.sh
+    PATH=`pwd`/install/bin:$PATH
+fi
+snapshot_base=~/tmp
+snapshot_name=pfiles-$1
+snapshot_dir=$snapshot_base/$snapshot_name
+snapshot_archive_path=$snapshot_dir.tar.xz

--- a/infra/scripts/prepare-pfiles.sh
+++ b/infra/scripts/prepare-pfiles.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# This script is run on the mud host as part of a player file upgrade workflow.
+# It creates an archive of the player and gods directories. The archive can be
+# used to restore the original pfiles if the upgrades don't work out.
+# It adds the copied files to a temp git repo then runs `pfu` to perform upgrades on the 
+# player files. You can then review the git diffs before carrying the upgrades
+# back into the production player directory using upgrade-pfiles.sh
+# In dev, run this from the project root directory.
+. "${0%/*}/pfile-upgrade-lib.sh"
+orig_dir=`pwd`
+cd $MUD_DATA_DIR
+if [ -d $snapshot_dir ]; then
+    echo "Snapshot already exists, replacing it."
+    rm -rf $snapshot_dir
+fi
+mkdir -p $snapshot_dir
+echo "Snapshotting player files into $snapshot_dir"
+cp -r player gods $snapshot_dir
+echo "Creating backup tarball of this snapshot: $snapshot_archive_path"
+cd $snapshot_base
+tar Jcf $snapshot_archive_path $snapshot_name
+cd $snapshot_name
+echo "Initializing git repo for player file upgrade"
+git init -q
+git add .
+git commit -qm 'importing pfiles'
+cd $orig_dir
+echo "Running pfu to upgrade the player files in $snapshot_dir"
+# As pfu uses the same configuration as the mud, point MUD_DATA_DIR
+# at the snapshot directory so that it processes the copy of the player files.
+MUD_DATA_DIR=$snapshot_dir pfu
+echo "Review the git diff output in $snapshot_dir then run upgrade-pfiles.sh"

--- a/infra/scripts/upgrade-pfiles.sh
+++ b/infra/scripts/upgrade-pfiles.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# This script is run on the mud host as part of a player file upgrade workflow.
+# It's used after prepare-pfiles.sh to accept the upgraded pfiles and copy
+# them back into the mud's player dir.
+. "${0%/*}/pfile-upgrade-lib.sh"
+
+cd $MUD_DATA_DIR
+cp --preserve=timestamps $snapshot_dir/player/* player
+cp --preserve=timestamps $snapshot_dir/gods/* gods

--- a/src/AFFECT_DATA.cpp
+++ b/src/AFFECT_DATA.cpp
@@ -49,7 +49,9 @@ void AFFECT_DATA::modify(Char &ch, bool apply) const {
     case AffectLocation::Weight:
     case AffectLocation::Gold:
     case AffectLocation::Exp:
-        // TODO(193) should we do something with these?
+        // TODO(193) should we do something with these? If they get implemented then it may involve
+        // persisting a pristine (unmodified) field value like pcdata.true_sex, and also updating
+        // pfu's ResetChar to reset the value back to the pristine before applying any affects.
         break;
     }
 }

--- a/src/Char.hpp
+++ b/src/Char.hpp
@@ -2,6 +2,7 @@
 
 #include "AFFECT_DATA.hpp"
 #include "AffectList.hpp"
+#include "CharVersion.hpp"
 #include "Constants.hpp"
 #include "Descriptor.hpp"
 #include "ExtraFlags.hpp"
@@ -21,6 +22,11 @@ struct OBJ_DATA;
 struct ROOM_INDEX_DATA;
 struct GEN_DATA;
 struct MPROG_ACT_LIST;
+
+struct LastLoginInfo {
+    std::string login_from;
+    std::string login_at;
+};
 
 /*
  * One character (PC or NPC).
@@ -45,7 +51,7 @@ struct Char {
     GEN_DATA *gen_data{};
     std::string name;
 
-    sh_int version{};
+    CharVersion version{};
     std::string short_descr;
     std::string long_descr;
     std::string description;

--- a/src/CharVersion.hpp
+++ b/src/CharVersion.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Types.hpp"
+
+#include <climits>
+
+// CharVersion is used in the Char.version field and tracks the version format that
+// player files are saved as. Originally this was significant because the mud took
+// a lazy approach to handling "upgrades" to the content of player files. When a player
+// logged in, it'd check their version field and then perform any required updates to their data.
+// But these versions and the actions to perform were always coded in a haphazard way,
+// and the logic to perform those upgrades had to be kept in the mud indefinitely.
+// Now CharVersion is used by `pfu` CharUpgraders.
+enum class CharVersion : ush_int {
+    Zero = 0,
+    // Skip 1 & 2 as we have no data with those versions
+    Three = 3,
+    Four = 4,
+    Five = 5,
+    // Latest is the value that fwrite_char() is meant to use when saving a Char.
+    Latest = Five,
+    Max = SHRT_MAX
+};

--- a/src/CharVersion.hpp
+++ b/src/CharVersion.hpp
@@ -2,7 +2,8 @@
 
 #include "Types.hpp"
 
-#include <climits>
+#include <limits>
+#include <type_traits>
 
 // CharVersion is used in the Char.version field and tracks the version format that
 // player files are saved as. Originally this was significant because the mud took
@@ -10,7 +11,7 @@
 // logged in, it'd check their version field and then perform any required updates to their data.
 // But these versions and the actions to perform were always coded in a haphazard way,
 // and the logic to perform those upgrades had to be kept in the mud indefinitely.
-// Now CharVersion is used by `pfu` CharUpgraders.
+// Now CharVersion is used by `pfu` upgrade tasks.
 enum class CharVersion : ush_int {
     Zero = 0,
     // Skip 1 & 2 as we have no data with those versions
@@ -19,5 +20,5 @@ enum class CharVersion : ush_int {
     Five = 5,
     // Latest is the value that fwrite_char() is meant to use when saving a Char.
     Latest = Five,
-    Max = SHRT_MAX
+    Max = std::numeric_limits<std::underlying_type_t<CharVersion>>::max()
 };

--- a/src/Descriptor.hpp
+++ b/src/Descriptor.hpp
@@ -36,7 +36,6 @@ enum class DescriptorState {
 };
 
 const char *short_name_of(DescriptorState state);
-
 /*
  * Descriptor (channel) structure.
  */
@@ -107,7 +106,9 @@ public:
     void set_endpoint(uint32_t netaddr, uint16_t port, std::string_view raw_full_hostname);
 
     [[nodiscard]] const std::string &host() const noexcept { return masked_host_; }
+    void host(std::string_view host) { masked_host_ = host; }
     [[nodiscard]] std::string login_time() const noexcept;
+    void login_time(Time login_time) { login_time_ = login_time; }
 
     [[nodiscard]] bool flush_output() noexcept;
 

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(test)
 add_executable(areas areas.cpp)
 target_link_libraries(areas xania_lib CONAN_PKG::lyra)
 target_compile_definitions(areas PRIVATE DEFAULT_AREA_PATH="${CMAKE_SOURCE_DIR}/area")
@@ -5,3 +6,11 @@ target_compile_definitions(areas PRIVATE DEFAULT_AREA_PATH="${CMAKE_SOURCE_DIR}/
 add_executable(map map.cpp)
 target_link_libraries(map xania_lib CONAN_PKG::lyra)
 target_compile_definitions(map PRIVATE DEFAULT_AREA_PATH="${CMAKE_SOURCE_DIR}/area")
+
+add_library(pfu_lib STATIC pfu.cpp)
+target_link_libraries(pfu_lib xania_lib xania_common)
+
+add_executable(pfu pfumain.cpp)
+target_link_libraries(pfu pfu_lib CONAN_PKG::lyra)
+
+install(TARGETS pfu RUNTIME DESTINATION bin)

--- a/src/apps/pfu.cpp
+++ b/src/apps/pfu.cpp
@@ -1,0 +1,195 @@
+#include "pfu.hpp"
+#include "VnumRooms.hpp"
+#include "WrappedFd.hpp"
+#include "common/Configuration.hpp"
+#include "common/Time.hpp"
+#include "handler.hpp"
+#include "merc.h"
+#include "save.hpp"
+
+#include <dirent.h>
+#include <magic_enum.hpp>
+#include <optional>
+#include <range/v3/algorithm/fill.hpp>
+#include <range/v3/view/filter.hpp>
+#include <spdlog/spdlog.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace pfu {
+
+// Register new tasks here. Ideally in ascending order of CharVersion. You can have multiple
+// tasks for any given version.
+Tasks register_tasks() {
+    Tasks all_tasks;
+    all_tasks.emplace_back(std::make_unique<ResetModifiableAttrs>(CharVersion::Five));
+    return all_tasks;
+}
+
+std::vector<std::string> collect_player_names(const std::string &player_dir, Logger &logger) {
+    DIR *dir = opendir(player_dir.c_str());
+    if (!dir) {
+        logger.critical("Couldn't open player directory: {}", strerror(errno));
+        return {};
+    }
+    std::vector<std::string> names;
+    struct dirent *entry;
+    struct stat st;
+    while ((entry = readdir(dir))) {
+        if (entry->d_type == DT_REG) {
+            std::string filename = player_dir + entry->d_name;
+            if (!stat(filename.c_str(), &st) && st.st_size > 0) {
+                names.emplace_back(entry->d_name);
+            } else {
+                logger.warn("Ignoring bad player file: {}", filename);
+            }
+        }
+    }
+    closedir(dir);
+    return names;
+}
+
+void upgrade_players(const std::vector<std::string> &players, Logger &logger) {
+    auto all_tasks = register_tasks();
+    auto succeeded = 0;
+    auto failed = 0;
+    const CharSaver saver;
+    for (auto &player : players) {
+        if (upgrade_player(player, all_tasks, logger, [&saver](const Char &ch) { saver.save(ch); })) {
+            succeeded++;
+        } else {
+            failed++;
+        }
+    }
+    logger.info("Processed characters: {} succeeded, {} failed.", succeeded, failed);
+}
+
+std::optional<Time> try_parse_login_at(std::string &login_at) {
+    if (login_at.empty()) {
+        return std::nullopt;
+    }
+    std::tm tm_login;
+    // Includes older formats used for login time.
+    for (const auto format : {"%Y-%m-%d %H:%M:%SZ", "%Y-%m-%d %H:%M:%S", "%a %b %d %H:%M:%S %Y"}) {
+        memset(&tm_login, 0, sizeof(std::tm));
+        if (strptime(login_at.c_str(), format, &tm_login)) {
+            return Clock::from_time_t(mktime(&tm_login));
+        }
+    }
+    return std::nullopt;
+}
+
+// Reset/repair Char attributes.
+ResetModifiableAttrs::ResetModifiableAttrs(CharVersion version) : UpgradeTask(version) {}
+
+// This method replaces the old handler.cpp:reset_char(). Originally it was executed
+// every time a char logged in and it reset the char's armour and attributes
+// to a healthy starting value before applying modifiers from spell and object "affects". Unclear why
+// this was introduced, but it was probably to fix "attribute drift" e.g. where the modifiers of a spell affect
+// got changed in the code without retrospectively adjusting the player's stats.
+void ResetModifiableAttrs::execute(Char &ch) const {
+    OBJ_DATA *obj;
+    // Restore the character to his/her true condition
+    // All of the attributes reset here are ones that can be modified in AFFECT_DATA.cpp
+    ranges::fill(ch.mod_stat, 0);
+    ch.max_hit = ch.pcdata->perm_hit;
+    ch.max_mana = ch.pcdata->perm_mana;
+    ch.max_move = ch.pcdata->perm_move;
+    // #216 -1 is initial value for armour now
+    ranges::fill(ch.armor, -1);
+    ch.hitroll = 0;
+    ch.damroll = 0;
+    ch.saving_throw = 0;
+    ch.sex = ch.pcdata->true_sex;
+    // add back object effects
+    for (auto loc = 0; loc < MAX_WEAR; loc++) {
+        obj = get_eq_char(&ch, loc);
+        if (!obj)
+            continue;
+        for (size_t i = 0; i < ch.armor.size(); i++)
+            ch.armor[i] -= apply_ac(obj, loc, i);
+
+        if (!obj->enchanted)
+            for (const auto &af : obj->pIndexData->affected)
+                af.apply(ch);
+
+        for (auto &af : obj->affected)
+            af.apply(ch);
+    }
+    // add back spell effects
+    for (auto &af : ch.affected)
+        af.apply(ch);
+}
+
+CharUpgraderResult::CharUpgraderResult() : ch_(nullptr), upgraded_(false) {}
+
+CharUpgraderResult::CharUpgraderResult(Char *ch, bool upgraded) : ch_(ch), upgraded_(upgraded) {}
+
+CharUpgraderResult::~CharUpgraderResult() {
+    if (ch_) {
+        extract_char(ch_, true);
+    }
+}
+
+CharUpgraderResult::operator bool() const noexcept { return ch_ && !ch_->name.empty(); }
+
+CharUpgraderResult::operator Char &() const noexcept { return *ch_; }
+
+CharUpgrader::CharUpgrader(std::string_view name, const Tasks &all_tasks, Logger &logger)
+    : name_(name), desc_(Descriptor(0)), all_tasks_(all_tasks), logger_(logger) {}
+
+auto CharUpgrader::required_tasks(const Char &ch) const {
+    return all_tasks_ | ranges::views::filter([&ch](const auto &upgrade) { return upgrade->is_required(ch); });
+}
+
+CharUpgraderResult CharUpgrader::upgrade() {
+    if (auto ch = simulate_login()) {
+        bool upgraded{};
+        logger_.debug("{}", name_);
+        // Chars that have an malformed pfile will have been created and added
+        // to the world, but no tasks should be run. Released when the result is destroyed.
+        if (!ch->name.empty()) {
+            for (auto &task : required_tasks(*ch)) {
+                task->execute(*ch);
+                upgraded = true;
+            }
+        } else
+            logger_.warn("Invalid player file: {}", name_);
+        return {ch, upgraded};
+    }
+    return {};
+}
+
+Char *CharUpgrader::simulate_login() {
+    if (auto fp = WrappedFd::open(filename_for_player(name_))) {
+        LastLoginInfo last_login;
+        // This snippet is very similar to what's in nanny() and try_load_player().
+        Char *ch = new Char();
+        ch->pcdata = std::make_unique<PcData>();
+        load_into_char(*ch, last_login, fp);
+        char_list.add_front(ch);
+        desc_.character(ch);
+        ch->desc = &desc_;
+        // Retain the original login from & time if possible.
+        if (!last_login.login_from.empty()) {
+            desc_.host(last_login.login_from);
+        }
+        auto parsed_time = try_parse_login_at(last_login.login_at);
+        if (parsed_time) {
+            desc_.login_time(*parsed_time);
+        }
+        if (ch->in_room) {
+            char_to_room(ch, ch->in_room);
+        } else {
+            char_to_room(ch, get_room_index(rooms::MidgaardTemple));
+        }
+        if (ch->pet) {
+            char_to_room(ch->pet, ch->in_room);
+        }
+        return ch;
+    } else
+        return nullptr;
+}
+
+}

--- a/src/apps/pfu.hpp
+++ b/src/apps/pfu.hpp
@@ -1,0 +1,92 @@
+#pragma once
+#include "Char.hpp"
+#include "CharVersion.hpp"
+#include <spdlog/spdlog.h>
+#include <vector>
+
+namespace pfu {
+
+class UpgradeTask {
+public:
+    explicit UpgradeTask(const CharVersion upgrade_version) : upgrade_version_(upgrade_version) {}
+    virtual ~UpgradeTask() = default;
+    [[nodiscard]] bool is_required(const Char &ch) const { return ch.version < upgrade_version_; }
+    virtual void execute(Char &ch) const = 0;
+
+private:
+    const CharVersion upgrade_version_;
+};
+
+// Reset/repair Char attributes that are modifiable via spell/item bonii.
+// This task accepts a version because over time the expectation is that
+// it will be reused for future CharVersions. It _could_ be configured to
+// use CharVersion::Max and thus run every time, but instead register_tasks()
+// will include it explicitly for versions where we need it to run.
+class ResetModifiableAttrs : public UpgradeTask {
+public:
+    ResetModifiableAttrs(CharVersion version);
+    void execute(Char &ch) const override;
+};
+
+struct CharUpgraderResult {
+    CharUpgraderResult();
+    CharUpgraderResult(Char *ch, bool upgraded);
+    ~CharUpgraderResult(); // remove the upgraded Char from the world
+    // returns true if the Char was logged in and is valid. false if it couldn't be loaded (e.g. empty file)
+    // and it's unnecessary for any upgrade tasks to have been processed because save should be called for
+    // all valid chars.
+    operator bool() const noexcept;
+    operator Char &() const noexcept;
+    Char *ch_; // set if a Char file was found, but it may still be invalid.
+    bool upgraded_; // true if at least one task was performed
+};
+
+using Tasks = std::vector<std::unique_ptr<UpgradeTask>>;
+using Logger = spdlog::logger;
+
+// Log in one character and apply any relevant upgrades. Doesn't save the character.
+class CharUpgrader {
+public:
+    explicit CharUpgrader(std::string_view name, const Tasks &all_tasks, Logger &logger);
+
+    CharUpgraderResult upgrade();
+
+private:
+    // Simulates logging in a player character using its name.
+    // Returns a new Char on the heap that's released when CharUpgraderResult is destroyed,
+    // or null if it can't be loaded.
+    // Retains the Char's original last login from/time, where possible.
+    Char *simulate_login();
+    // Filter all_tasks_ to include those that apply to the Char being upgraded.
+    auto required_tasks(const Char &ch) const;
+
+    const std::string_view name_;
+    // A temporary Descriptor required when shoe-horning the Char into the world, it has
+    // a mutual reference with Char, setup in simulate_login().
+    Descriptor desc_;
+    const Tasks &all_tasks_;
+    Logger &logger_;
+};
+
+Tasks register_tasks();
+std::vector<std::string> collect_player_names(const std::string &dirname, Logger &logger);
+void upgrade_players(const std::vector<std::string> &players, Logger &logger);
+
+// Instantiate a player character, upgrade/tweak it, save it then extract it from the world.
+// This saves the Char out to the player file even if no UpgradeTasks are executed.
+// Largely because the mud has introduced several subtle changes to Chars that are
+// implicitly unversioned (e.g. addition of the Pronouns fields) and we want those things
+// to be saved when upgrading legacy files.
+template <typename SaveChar>
+bool upgrade_player(std::string_view player, const Tasks &all_tasks, Logger &logger, SaveChar saveChar) {
+    CharUpgrader cup(player, all_tasks, logger);
+    auto result = cup.upgrade();
+    if (result) {
+        saveChar(result);
+    }
+    return result;
+}
+
+std::optional<Time> try_parse_login_at(std::string &login_at);
+
+}

--- a/src/apps/pfu.hpp
+++ b/src/apps/pfu.hpp
@@ -1,6 +1,7 @@
 #pragma once
+
 #include "Char.hpp"
-#include "CharVersion.hpp"
+
 #include <spdlog/spdlog.h>
 #include <vector>
 
@@ -29,7 +30,7 @@ public:
 };
 
 struct CharUpgraderResult {
-    CharUpgraderResult();
+    CharUpgraderResult() = default;
     CharUpgraderResult(Char *ch, bool upgraded);
     ~CharUpgraderResult(); // remove the upgraded Char from the world
     // returns true if the Char was logged in and is valid. false if it couldn't be loaded (e.g. empty file)
@@ -37,8 +38,8 @@ struct CharUpgraderResult {
     // all valid chars.
     operator bool() const noexcept;
     operator Char &() const noexcept;
-    Char *ch_; // set if a Char file was found, but it may still be invalid.
-    bool upgraded_; // true if at least one task was performed
+    Char *ch_{}; // set if a Char file was found, but it may still be invalid.
+    bool upgraded_{}; // true if at least one task was performed
 };
 
 using Tasks = std::vector<std::unique_ptr<UpgradeTask>>;

--- a/src/apps/pfumain.cpp
+++ b/src/apps/pfumain.cpp
@@ -1,0 +1,55 @@
+#include "common/Configuration.hpp"
+#include "handler.hpp"
+#include "pfu.hpp"
+
+#include <fmt/format.h>
+#include <lyra/lyra.hpp>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+extern void boot_db();
+
+// pfu - player file upgrade utility for bulk upgrading all player files
+// as part of a release. Especially where the release contains code changes
+// that will affect character stats or anything else that ought to be
+// persisted in the pfiles.
+// This is intended to be used with the prepare-pfiles.sh wrapper script.
+//
+// There are some limitations right now:
+// - There's only a single "loader" for pfiles, the default one used by the mud.
+//   But this may need to be refactored to support a separate loader for legacy formats.
+// - Likewise there's only a single "saver", the one used by the mud.
+//   In due course this can probably be refactored to introduce
+//   a new saver that writes the pfiles out in a different format e.g. yaml.
+// - It could be enhanced to have cmd line arg to support processing a specific file.
+
+int main(int argc, const char **argv) {
+    auto sink = std::make_shared<spdlog::sinks::stdout_color_sink_st>();
+    auto logger = spdlog::logger("pfu", sink);
+    bool help{};
+    bool verbose{};
+    auto cli = lyra::cli()
+               | lyra::help(help).description("Perform upgrades on a copy of production or test player files")
+               | lyra::opt(verbose)["-V"]("verbose logging");
+
+    auto result = cli.parse({argc, argv});
+    if (!result) {
+        fmt::print("Error in command line: {}\n", result.errorMessage());
+        exit(1);
+    } else if (help) {
+        fmt::print("{}", cli);
+        exit(0);
+    }
+    if (verbose) {
+        logger.set_level(spdlog::level::debug);
+    }
+    const auto player_dir = Configuration::singleton().player_dir();
+    const auto names = pfu::collect_player_names(player_dir, logger);
+    if (names.empty()) {
+        logger.critical("No players found!");
+        exit(1);
+    }
+    boot_db();
+    pfu::upgrade_players(names, logger);
+    reap_old_chars();
+}

--- a/src/apps/test/CMakeLists.txt
+++ b/src/apps/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories(..)
+file(GLOB SOURCE_FILES CONFIGURE_DEPENDS *.cpp *.hpp)
+add_executable(apps_test ${SOURCE_FILES})
+target_compile_definitions(apps_test PUBLIC CATCH_CONFIG_EXTERNAL_INTERFACES CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test_data")
+target_link_libraries(apps_test pfu_lib CONAN_PKG::catch2)
+add_test(NAME apps_test COMMAND $<TARGET_FILE:apps_test>)

--- a/src/apps/test/main.cpp
+++ b/src/apps/test/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/src/apps/test/pfutest.cpp
+++ b/src/apps/test/pfutest.cpp
@@ -1,0 +1,133 @@
+#include "pfu.hpp"
+#include "../test/MemFile.hpp"
+#include "../test/fileutils.hpp"
+#include "common/Configuration.hpp"
+#include "save.hpp"
+#include "string_utils.hpp"
+
+#include <catch2/catch.hpp>
+#include <fmt/format.h>
+
+extern void boot_db();
+extern void reap_old_chars();
+
+using namespace pfu;
+
+namespace {
+spdlog::logger logger = spdlog::logger("pfutest");
+}
+
+struct LoadTinyMudOnce : Catch::TestEventListenerBase {
+    using TestEventListenerBase::TestEventListenerBase;
+
+    void testRunStarting([[maybe_unused]] Catch::TestRunInfo const &testInfo) override {
+        setenv(MUD_AREA_DIR_ENV, TEST_DATA_DIR "/area", 1);
+        setenv(MUD_DATA_DIR_ENV, TEST_DATA_DIR "/data", 1);
+        setenv(MUD_HTML_DIR_ENV, TEST_DATA_DIR "/html", 1);
+        setenv(MUD_PORT_ENV, "9000", 1);
+        boot_db();
+    }
+    void testRunEnded([[maybe_unused]] Catch::TestRunStats const &testRunStats) override { reap_old_chars(); }
+};
+CATCH_REGISTER_LISTENER(LoadTinyMudOnce)
+
+TEST_CASE("collect player names") {
+    SECTION("all non-empty player files found") {
+        const auto player_dir = Configuration::singleton().player_dir();
+
+        const auto names = collect_player_names(player_dir, logger);
+
+        std::vector<std::string> expected = {"Versionfour"};
+        REQUIRE(names == expected);
+    }
+}
+
+TEST_CASE("register tasks") {
+    SECTION("expected task count") {
+        const auto all_tasks = register_tasks();
+
+        REQUIRE(all_tasks.size() == 1);
+    }
+}
+
+TEST_CASE("upgrade player") {
+    SECTION("v4 to latest") {
+        const auto all_tasks = register_tasks();
+        const auto player_dir = Configuration::singleton().player_dir();
+        test::MemFile god_file;
+        test::MemFile player_file;
+        const CharSaver saver;
+        auto result =
+            upgrade_player("Versionfour", all_tasks, logger, [&god_file, &player_file, &saver](const Char &ch) {
+                saver.save(ch, god_file.file(), player_file.file());
+            });
+        REQUIRE(result == true);
+        SECTION("upgraded file matches expected") {
+            auto expected = test::read_whole_file(player_dir + "/expected-upgrades/Versionfour");
+            auto actual = player_file.as_string_view();
+
+            CHECK(actual == expected);
+            if (actual != expected)
+                test::diff_mismatch(actual, expected);
+        }
+    }
+}
+
+namespace {
+Time make_expected_time() {
+    struct tm tm_login;
+    tm_login.tm_sec = 21;
+    tm_login.tm_min = 33;
+    tm_login.tm_hour = 10;
+    tm_login.tm_mday = 22;
+    tm_login.tm_mon = 1;
+    tm_login.tm_year = 100;
+    tm_login.tm_wday = 2;
+    tm_login.tm_yday = 52;
+    tm_login.tm_isdst = 0;
+    tm_login.tm_gmtoff = 0;
+    return Clock::from_time_t(mktime(&tm_login));
+}
+}
+
+TEST_CASE("login time format parsing") {
+    SECTION("valid timestamps") {
+        auto expected = make_expected_time();
+        std::string last_login = GENERATE("Tue Feb 22 10:33:21 2000", "2000-02-22 10:33:21", "2000-02-22 10:33:21Z");
+
+        SECTION("are parsed and converted") {
+            auto parsed = try_parse_login_at(last_login);
+
+            CHECK(parsed == expected);
+        }
+    }
+    SECTION("unsupported timestamp ignored") {
+        std::string last_login = "Feb 22 10:33:21 2000";
+        auto parsed = try_parse_login_at(last_login);
+
+        REQUIRE(!parsed);
+    }
+    SECTION("empty timestamp ignored") {
+        std::string last_login = "";
+        auto parsed = try_parse_login_at(last_login);
+
+        REQUIRE(!parsed);
+    }
+}
+
+TEST_CASE("required tasks") {
+    ResetModifiableAttrs task(CharVersion::Five);
+    Char ch;
+    SECTION("required") {
+        ch.version = CharVersion::Four;
+        auto required = task.is_required(ch);
+
+        REQUIRE(required);
+    }
+    SECTION("not required") {
+        ch.version = CharVersion::Five;
+        auto required = task.is_required(ch);
+
+        REQUIRE(!required);
+    }
+}

--- a/src/apps/test/test_data/area/area.lst
+++ b/src/apps/test/test_data/area/area.lst
@@ -1,0 +1,2 @@
+limbo_test.are
+$

--- a/src/apps/test/test_data/area/limbo_test.are
+++ b/src/apps/test/test_data/area/limbo_test.are
@@ -1,0 +1,109 @@
+#AREA	
+limbo_test.are~
+Limbotest~
+{None } Faramir    Limbotest~
+1 100
+
+#ROOMS
+#1
+The Void~
+A sign says "This is just a test of the void".
+~
+8 1
+S
+
+#2
+Limbo~
+A sign says "This is just a test of limbo".
+~
+8 1
+S
+
+#3001
+The Temple of Isca~
+A sign says "This is just a test of the temple".
+~
+4|8 0
+S
+#0
+
+#MOBILES
+#1
+Joe~
+Joe the Plumber~
+Joey is busy plumbing.
+~
+~
+unique~
+0 0 1000 0
+26 5 5d10+550 26d5+100 4d6+3 chomp
+-30 -30 -30 -25
+MNc AB CD 0
+stand stand male 500
+DHZ ACDEFHJKPQUVX M 0
+
+#3093
+rottweiler dog pet~
+the rottweiler~
+A large, loyal rottweiler is here.
+~
+The rottweiler looks like a strong, fierce fighter.
+~
+dog~
+BU F 400 0
+7 3 6d10+60 1d1+149 2d4+1 bite
+-11 -11 -11 -7
+CDL 0 C 0
+stand stand male 0
+0 0 medium 0
+
+#0
+
+#OBJECTS
+#2
+coin gold~
+a gold coin~
+One miserable gold coin.~
+gold~
+money 0 A
+1 0 0 0 0
+0 1 0 P
+
+#809
+unique sword~
+unique sword~
+A brilliantly glowing sword is here.~
+steel~
+weapon ABGKU AN
+'sword' 2 4 'pierce' B
+3 23 6000 P
+
+#3350
+standard issue sword~
+a standard issue sword~
+You see a standard issue sword here.~
+steel~
+weapon G AN
+'sword' 2 4 'slash' 0
+3 5 75 P
+E
+sword~
+You see a sword of great craftsmanship.  Imprinted on the side is:
+Merc Industries
+~
+A
+18 1
+A
+19 1
+A
+20 -1
+
+#0
+
+#RESETS
+S
+
+#SPECIALS
+S
+
+#$

--- a/src/apps/test/test_data/data/player/Versionfour
+++ b/src/apps/test/test_data/data/player/Versionfour
@@ -1,0 +1,133 @@
+#PLAYER
+Name Versionfour~
+Vers 4
+Race orc~
+Sex  1
+Cla  0
+Levl 11
+Plyd 200824
+Note 956492971
+Scro 22
+Room 2
+HMV  123 123 172 172 160 160
+Gold 37560
+Exp  19180
+Act  134283516
+AfBy 512
+Comm 17004544
+Pos  8
+Prac 14
+Trai 1
+Save  -12
+Alig  5
+Hit   1
+Dam   1
+ACs 100 100 100 100
+Wimp  15
+Attr 18 18 20 13 16
+AMod 0 0 0 0 0
+Pass NOTREALLY~
+Titl ~
+Afk ~
+Colo 1
+Prmt %h [%B] %m/%M %x> ~
+Pnts 53
+TSex 1
+LLev 26
+HMVP 123 172 160
+Info_message ~
+LastLoginFrom localh*** [#249896952128253326]~
+LastLoginAt Fri Mar 24 18:46:08 2000
+~
+Prefix ~
+HourOffset 0
+MinOffset 0
+ExtraBits 0000000000000000000000000000000000000000000000000000000000000000~
+Cond 0 21 21
+Possessive ~
+Subjective ~
+Objective ~
+Reflexive ~
+Sk 1 'acid blast'
+Sk 51 'armor'
+Sk 1 'blindness'
+Sk 87 'burning hands'
+Sk 1 'cancellation'
+Sk 1 'chain lightning'
+Sk 1 'change sex'
+Sk 65 'chill touch'
+Sk 1 'colour spray'
+Sk 1 'cure poison'
+Sk 1 'curse'
+Sk 1 'dispel magic'
+Sk 1 'energy drain'
+Sk 1 'insanity'
+Sk 1 'fireball'
+Sk 42 'giant strength'
+Sk 1 'haste'
+Sk 1 'regeneration'
+Sk 1 'lethargy'
+Sk 1 'infravision'
+Sk 1 'lightning bolt'
+Sk 58 'magic missile'
+Sk 1 'plague'
+Sk 1 'poison'
+Sk 1 'protection evil'
+Sk 1 'protection good'
+Sk 1 'refresh'
+Sk 1 'sanctuary'
+Sk 1 'shield'
+Sk 75 'shocking grasp'
+Sk 1 'stone skin'
+Sk 42 'weaken'
+Sk 79 'dagger'
+Sk 51 'sword'
+Sk 1 'berserk'
+Sk 1 'second attack'
+Sk 1 'fast healing'
+Sk 28 'meditation'
+Sk 1 'scrolls'
+Sk 1 'staves'
+Sk 47 'wands'
+Sk 1 'throw'
+Sk 50 'recall'
+Gr 'rom basics'
+Gr 'mage basics'
+Gr 'combat'
+Gr 'enhancement'
+Gr 'maledictions'
+Gr 'protective'
+End
+
+#O
+Vnum 3350
+Nest 0
+Wear 14
+Lev  3
+Cost 75
+End
+
+#O
+Vnum 809
+Nest 0
+ExtF 1088
+Wear -1
+Lev  3
+Cost 75
+End
+
+#PET
+Vnum 3093
+Name rottweiler dog pet~
+Desc A neck tag says 'I belong to Versionfour'~
+Sex  1
+HMV  95 95 101 101 100 100
+Act  1048835
+AfBy 0
+Comm 7340032
+Pos  8
+ACs  40 40 40 80
+Attr 12 12 12 14 12
+AMod 0 0 0 0 0
+End
+#END

--- a/src/apps/test/test_data/data/player/expected-upgrades/Versionfour
+++ b/src/apps/test/test_data/data/player/expected-upgrades/Versionfour
@@ -1,0 +1,132 @@
+#PLAYER
+Name Versionfour~
+Vers 5
+Race orc~
+Sex  1
+Cla  0
+Levl 11
+Plyd 200824
+Note 956492971
+Scro 22
+Room 2
+HMV  123 123 172 172 160 160
+Gold 37560
+Exp  19180
+Act  134283516
+AfBy 512
+Comm 17004544
+Pos  8
+Prac 14
+Trai 1
+Save  -1
+Alig  5
+Hit   1
+Dam   1
+ACs -1 -1 -1 -1
+Wimp  15
+Attr 18 18 20 13 16
+AMod 0 0 0 0 0
+Pass NOTREALLY~
+Titl ~
+Afk ~
+Colo 1
+Prmt %h [%B] %m/%M %x> ~
+Pnts 53
+TSex 1
+LLev 26
+HMVP 123 172 160
+Info_message ~
+LastLoginFrom localh*** [#249896952128253326]~
+LastLoginAt 2000-03-24 18:46:08Z~
+Prefix ~
+HourOffset 0
+MinOffset 0
+ExtraBits 0000000000000000000000000000000000000000000000000000000000000000~
+Cond 0 21 21
+Possessive ~
+Subjective ~
+Objective ~
+Reflexive ~
+Sk 1 'acid blast'
+Sk 51 'armor'
+Sk 1 'blindness'
+Sk 87 'burning hands'
+Sk 1 'cancellation'
+Sk 1 'chain lightning'
+Sk 1 'change sex'
+Sk 65 'chill touch'
+Sk 1 'colour spray'
+Sk 1 'cure poison'
+Sk 1 'curse'
+Sk 1 'dispel magic'
+Sk 1 'energy drain'
+Sk 1 'insanity'
+Sk 1 'fireball'
+Sk 42 'giant strength'
+Sk 1 'haste'
+Sk 1 'regeneration'
+Sk 1 'lethargy'
+Sk 1 'infravision'
+Sk 1 'lightning bolt'
+Sk 58 'magic missile'
+Sk 1 'plague'
+Sk 1 'poison'
+Sk 1 'protection evil'
+Sk 1 'protection good'
+Sk 1 'refresh'
+Sk 1 'sanctuary'
+Sk 1 'shield'
+Sk 75 'shocking grasp'
+Sk 1 'stone skin'
+Sk 42 'weaken'
+Sk 79 'dagger'
+Sk 51 'sword'
+Sk 1 'berserk'
+Sk 1 'second attack'
+Sk 1 'fast healing'
+Sk 28 'meditation'
+Sk 1 'scrolls'
+Sk 1 'staves'
+Sk 47 'wands'
+Sk 1 'throw'
+Sk 50 'recall'
+Gr 'rom basics'
+Gr 'mage basics'
+Gr 'combat'
+Gr 'enhancement'
+Gr 'maledictions'
+Gr 'protective'
+End
+
+#O
+Vnum 3350
+Nest 0
+Wear 14
+Lev  3
+Cost 75
+End
+
+#O
+Vnum 809
+Nest 0
+ExtF 1049664
+Wear -1
+Lev  3
+Cost 75
+End
+
+#PET
+Vnum 3093
+Name rottweiler dog pet~
+Desc A neck tag says 'I belong to Versionfour'~
+Sex  1
+HMV  95 95 101 101 100 100
+Act  1048835
+AfBy 0
+Comm 7340032
+Pos  8
+ACs  40 40 40 80
+Attr 12 12 12 14 12
+AMod 0 0 0 0 0
+End
+#END

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -974,8 +974,6 @@ void nanny(Descriptor *d, const char *argument) {
         d->write("\n\rWelcome to Xania.  May your stay be eventful.\n\r");
         char_list.add_front(ch);
         d->state(DescriptorState::Playing);
-        reset_char(ch);
-
         /* Moog: tell doorman we logged in OK */
         {
             Packet p;
@@ -1014,7 +1012,7 @@ void nanny(Descriptor *d, const char *argument) {
             /* turn on the newbie's tips */
             ch->set_extra(EXTRA_TIP_WIZARD);
 
-        } else if (ch->in_room != nullptr) {
+        } else if (ch->in_room) {
             char_to_room(ch, ch->in_room);
         } else if (ch->is_immortal()) {
             char_to_room(ch, get_room_index(rooms::Chat));
@@ -1037,7 +1035,7 @@ void nanny(Descriptor *d, const char *argument) {
             ch->gold -= (ch->gold - 250000) / 2;
         }
 
-        if (ch->pet != nullptr) {
+        if (ch->pet) {
             char_to_room(ch->pet, ch->in_room);
             act("|P$n|W has entered the game.", ch->pet);
         }

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -22,7 +22,6 @@
 
 #include <cstdio>
 #include <cstring>
-#include <dirent.h>
 #include <sys/stat.h>
 #include <unordered_map>
 

--- a/src/merc.h
+++ b/src/merc.h
@@ -1352,7 +1352,6 @@ int get_skill(const Char *ch, int sn);
 int get_weapon_sn(Char *ch);
 int get_weapon_skill(Char *ch, int sn);
 int get_age(const Char *ch);
-void reset_char(Char *ch);
 int get_curr_stat(const Char *ch, Stat stat);
 int get_max_train(Char *ch, Stat stat);
 int can_carry_n(Char *ch);
@@ -1416,9 +1415,6 @@ const char *form_bit_name(int form_flags);
 const char *part_bit_name(int part_flags);
 const char *weapon_bit_name(int weapon_flags);
 const char *comm_bit_name(int comm_flags);
-
-/* info.c */
-void load_player_list();
 
 /* interp.c */
 void interpret(Char *ch, const char *argument);

--- a/src/save.hpp
+++ b/src/save.hpp
@@ -2,6 +2,7 @@
 
 #include "Char.hpp"
 #include "Descriptor.hpp"
+#include "WrappedFd.hpp"
 
 #include <memory>
 #include <string>
@@ -11,6 +12,15 @@
 std::string get_base_dir();
 std::string get_player_dir();
 std::string filename_for_player(std::string_view player_name);
+std::string filename_for_god(std::string_view player_name);
+
+class CharSaver {
+public:
+    // Save a player to its player file and related gods file.
+    void save(const Char &ch) const;
+    // A convenience so tests can write to specific destinations. Caller must close the files.
+    void save(const Char &ch, FILE *god_file, FILE *player_file) const;
+};
 
 void save_char_obj(const Char *ch);
 void save_char_obj(const Char *ch, FILE *fp);
@@ -20,4 +30,4 @@ struct LoadCharObjResult {
     std::unique_ptr<Char> character;
 };
 LoadCharObjResult try_load_player(std::string_view player_name);
-void load_into_char(Char &character, FILE *fp);
+void load_into_char(Char &character, LastLoginInfo &last_login, FILE *fp);

--- a/src/test/fileutils.hpp
+++ b/src/test/fileutils.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <catch2/catch.hpp>
+
+// Some helper functions for dealing with test data files.
+namespace test {
+
+std::string read_whole_file(const std::string &name) {
+    INFO("reading whole file " << name);
+    auto fp = ::fopen(name.c_str(), "rb");
+    REQUIRE(fp);
+    ::fseek(fp, 0, SEEK_END);
+    auto len = ::ftell(fp);
+    REQUIRE(len > 0);
+    size_t len_ok = (size_t)len;
+    ::fseek(fp, 0, SEEK_SET);
+    std::string result;
+    result.resize(len);
+    REQUIRE(::fread(result.data(), 1, len, fp) == len_ok);
+    ::fclose(fp);
+    return result;
+}
+
+void write_file(const std::string &filename, std::string_view data) {
+    INFO("writing file " << filename);
+    auto fp = ::fopen(filename.c_str(), "wb");
+    REQUIRE(fp);
+    REQUIRE(::fwrite(data.data(), 1, data.size(), fp) == data.size());
+    ::fclose(fp);
+}
+
+// short up deficiencies in diff reporting.
+void diff_mismatch(std::string_view lhs, std::string_view rhs) {
+    // If you find yourself debugging, set this ENV var to run meld.
+    if (!::getenv("MELD_ON_DIFF"))
+        return;
+    write_file("/tmp/lhs", lhs);
+    write_file("/tmp/rhs", rhs);
+    CHECK(system("meld /tmp/lhs /tmp/rhs") == 0);
+}
+
+}

--- a/src/test/test_data/player/Khirsah
+++ b/src/test/test_data/player/Khirsah
@@ -1,6 +1,6 @@
 #PLAYER
 Name Khirsah~
-Vers 4
+Vers 5
 Race orc~
 Sex  1
 Cla  0

--- a/src/test/test_data/player/Themoog
+++ b/src/test/test_data/player/Themoog
@@ -1,6 +1,6 @@
 #PLAYER
 Name TheMoog~
-Vers 4
+Vers 5
 Race human~
 Sex  1
 Cla  0


### PR DESCRIPTION
A new tool called `pfu` plus a pair of wrapper scripts. This enables us to proactively upgrade all player files as part of a release. It works by loading the game world, simulating logging in each char and then executing a list of tasks on the char before saving it. 

A grep reveals that on the host, all existing pfiles are either v3 or v4.

**Explicit Upgrades**

- Right now there's only one task - one that emulates  `reset_char()`  which previously was always run on login even if the Char didn't need it, and this is largely about resetting & recalculating any attributes that can be modified by item & spell effects.
- All pfiles are being upgrade to v5.

**Implicit Upgrades**

As well as the explicit tasks, there are several updates that pfu will make to existing pfiles simply by saving them:

- Unique Objects: Any objects a char owns that has been flagged UNIQUE gets its "ExtF" bits updated to set that bit.
- Adds empty pronouns.
- Removes `Info_` finger fields that we ditched last year.
- Removes `NewsRead` field.
- Some chars got a new bit in their `ExtraBits`, we must've added a new one at some point a long time ago.
- Reformats `LastLoginAt` to use our standard format (we've had 3 different formats!). Keeps whatever the timestamp was where possible.
