### PR TITLE
Macro death: Convert weapon flag macros to be an enum. check_enum_bit…

### DIFF
--- a/src/BitsWeaponFlag.hpp
+++ b/src/BitsWeaponFlag.hpp
@@ -8,14 +8,15 @@
 
 #include "common/StandardBits.hpp"
 
-// Weapon flags for custom behaviour.
-#define WEAPON_FLAMING (A)
-#define WEAPON_FROST (B)
-#define WEAPON_VAMPIRIC (C)
-#define WEAPON_SHARP (D)
-#define WEAPON_VORPAL (E)
-#define WEAPON_TWO_HANDS (F)
-#define WEAPON_POISONED (G)
-#define WEAPON_PLAGUED (I)
-#define WEAPON_LIGHTNING (J)
-#define WEAPON_ACID (K)
+enum class WeaponFlag : unsigned int {
+    Flaming = A,
+    Frost = B,
+    Vampiric = C,
+    Sharp = D,
+    Vorpal = E,
+    TwoHands = F,
+    Poisoned = G,
+    Plagued = I,
+    Lightning = J,
+    Acid = K
+};

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -55,4 +55,4 @@ bool Object::is_summon_corpse() const { return check_bit(extra_flags, ITEM_SUMMO
 bool Object::is_unique() const { return check_bit(extra_flags, ITEM_UNIQUE); }
 bool Object::is_vis_death() const { return check_bit(extra_flags, ITEM_VIS_DEATH); }
 
-bool Object::is_weapon_two_handed() const { return check_bit(value[4], WEAPON_TWO_HANDS); }
+bool Object::is_weapon_two_handed() const { return check_enum_bit(value[4], WeaponFlag::TwoHands); }

--- a/src/common/BitOps.hpp
+++ b/src/common/BitOps.hpp
@@ -5,22 +5,34 @@
 /*************************************************************************/
 #pragma once
 
+#include <magic_enum.hpp>
+
 template <typename F, typename B>
-inline bool check_bit(const F flag, const B bit) {
+inline bool check_bit(const F flag, const B bit) noexcept {
     return flag & bit;
 }
 
 template <typename F, typename B>
-inline bool set_bit(F &flag, const B bit) {
+inline bool check_enum_bit(const F flag, const B bit) noexcept {
+    return flag & magic_enum::enum_integer<B>(bit);
+}
+
+template <typename F, typename B>
+inline bool set_bit(F &flag, const B bit) noexcept {
     return flag |= bit;
 }
 
 template <typename F, typename B>
-inline bool clear_bit(F &flag, const B bit) {
+inline bool set_enum_bit(F &flag, const B bit) noexcept {
+    return flag |= magic_enum::enum_integer<B>(bit);
+}
+
+template <typename F, typename B>
+inline bool clear_bit(F &flag, const B bit) noexcept {
     return flag &= ~bit;
 }
 
 template <typename F, typename B>
-inline bool toggle_bit(F &flag, const B bit) {
+inline bool toggle_bit(F &flag, const B bit) noexcept {
     return flag ^= bit;
 }

--- a/src/entity_balance.cpp
+++ b/src/entity_balance.cpp
@@ -39,7 +39,6 @@ void mobbug(std::string_view str, MobIndexData *mob) {
 int report_object(Object *object, int boot) {
     int averagedam, allowedaverage;
     ObjectIndex *obj = object->objIndex;
-
     auto value =
         ranges::accumulate(obj->affected | ranges::views::transform(&AFFECT_DATA::worth), AFFECT_DATA::Value{});
 
@@ -49,28 +48,27 @@ int report_object(Object *object, int boot) {
         value.worth + (obj->type == ObjectType::Weapon ? (value.hit + value.damage) / 2 : value.hit + value.damage);
 
     /* Object specific routines */
-
     switch (obj->type) {
 
     case ObjectType::Weapon:
         /* Calculate the damage allowed and actual */
         allowedaverage = (object->level / 2) + 4;
-        if (check_bit(obj->value[4], WEAPON_TWO_HANDS) && check_bit(obj->wear_flags, ITEM_TWO_HANDS))
+        if (check_enum_bit(obj->value[4], WeaponFlag::TwoHands) && check_bit(obj->wear_flags, ITEM_TWO_HANDS))
             allowedaverage += std::max(1, (allowedaverage) / 20);
         averagedam = (obj->value[1] * obj->value[2] + obj->value[1]) / 2;
         if ((averagedam > allowedaverage) && boot) {
             objectbug("average damage too high", obj);
         }
         /* Add to worth for each weapon type */
-        if (check_bit(obj->value[4], WEAPON_FLAMING))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Flaming))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_FROST))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Frost))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_VAMPIRIC))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Vampiric))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_SHARP))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Sharp))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_VORPAL))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Vorpal))
             worth++;
         break;
 

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -536,7 +536,7 @@ void one_hit(Char *ch, Char *victim, const skill_type *opt_skill) {
 
             /* Sharp weapon flag implemented by Wandera */
             if ((wield != nullptr) && (wield->type == ObjectType::Weapon) && !self_hitting)
-                if (check_bit(wield->value[4], WEAPON_SHARP) && number_percent() > 98) {
+                if (check_enum_bit(wield->value[4], WeaponFlag::Sharp) && number_percent() > 98) {
                     dam *= 2;
                     act("Sunlight glints off your sharpened blade!", ch, nullptr, victim, To::Char);
                     act("Sunlight glints off $n's sharpened blade!", ch, nullptr, victim, To::NotVict);
@@ -546,7 +546,7 @@ void one_hit(Char *ch, Char *victim, const skill_type *opt_skill) {
             /* Vorpal weapon flag implemented by Wandera and Death*/
             /* Previously this quadrupled damage if you landed a lucky hit. The bonus is now a bit less overpowered. */
             if ((wield != nullptr) && (wield->type == ObjectType::Weapon)) {
-                if (check_bit(wield->value[4], WEAPON_VORPAL)) {
+                if (check_enum_bit(wield->value[4], WeaponFlag::Vorpal)) {
                     if (dam == (1 + wield->value[2]) * wield->value[1] / 2) {
                         dam *= 1.3;
                         act("With a blood curdling scream you leap forward swinging\n\ryour weapon in a great arc.", ch,
@@ -600,14 +600,14 @@ void one_hit(Char *ch, Char *victim, const skill_type *opt_skill) {
     if (wield == nullptr || wield->type != ObjectType::Weapon)
         return;
 
-    if ((check_bit(wield->value[4], WEAPON_POISONED)) && !victim->is_aff_poison()) {
+    if ((check_enum_bit(wield->value[4], WeaponFlag::Poisoned)) && !victim->is_aff_poison()) {
         if (number_percent() > 75) {
             int p_sn = skill_lookup("poison");
             spell_poison(p_sn, wield->level, ch, victim);
         }
     }
 
-    if ((check_bit(wield->value[4], WEAPON_PLAGUED)) && !victim->is_aff_plague()) {
+    if ((check_enum_bit(wield->value[4], WeaponFlag::Plagued)) && !victim->is_aff_plague()) {
         if (number_percent() > 75) {
             int p_sn = skill_lookup("plague");
             spell_plague(p_sn, wield->level, ch, victim);
@@ -779,7 +779,8 @@ bool damage(Char *ch, Char *victim, const int raw_damage, const AttackType atk_t
 
     wield = get_eq_char(ch, WEAR_WIELD);
 
-    if ((wield != nullptr) && (wield->type == ObjectType::Weapon) && (check_bit(wield->value[4], WEAPON_VAMPIRIC))) {
+    if ((wield != nullptr) && (wield->type == ObjectType::Weapon)
+        && (check_enum_bit(wield->value[4], WeaponFlag::Vampiric))) {
         ch->hit += (adjusted_damage / 100) * 10;
         victim->hit -= (adjusted_damage / 100) * 10;
     }
@@ -1734,7 +1735,7 @@ void do_berserk(Char *ch) {
         affect_to_char(ch, af);
 
         /* if ( (wield !=nullptr) && (wield->type == ObjectType::Weapon) &&
-              (check_bit(wield->value[4], WEAPON_FLAMING)))
+              (check_enum_bit(wield->value[4], WeaponFlag::Flaming)))
             {
               ch->send_line("Your great energy causes your weapon to burst into
   flame.");
@@ -2481,15 +2482,14 @@ void do_sharpen(Char *ch) {
         ch->send_line("You can't do that or you may cut yourself.");
         return;
     }
-
-    if (check_bit(weapon->value[4], WEAPON_SHARP)) {
+    if (check_enum_bit(weapon->value[4], WeaponFlag::Sharp)) {
         ch->send_line("It can't get any sharper.");
         return;
     }
 
     chance = get_skill(ch, gsn_sharpen);
     if (number_percent() <= chance) {
-        set_bit(weapon->value[4], WEAPON_SHARP);
+        set_enum_bit(weapon->value[4], WeaponFlag::Sharp);
         ch->send_line("You sharpen the weapon to a fine, deadly point.");
     } else {
         ch->send_line("Your lack of skill removes all bonuses on this weapon.");

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1296,27 +1296,26 @@ const char *part_bit_name(int part_flags) {
 
 const char *weapon_bit_name(int weapon_flags) {
     static char buf[512];
-
     buf[0] = '\0';
-    if (weapon_flags & WEAPON_FLAMING)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Flaming))
         strcat(buf, " flaming");
-    if (weapon_flags & WEAPON_FROST)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Frost))
         strcat(buf, " frost");
-    if (weapon_flags & WEAPON_VAMPIRIC)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Vampiric))
         strcat(buf, " vampiric");
-    if (weapon_flags & WEAPON_SHARP)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Sharp))
         strcat(buf, " sharp");
-    if (weapon_flags & WEAPON_VORPAL)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Vorpal))
         strcat(buf, " vorpal");
-    if (weapon_flags & WEAPON_TWO_HANDS)
+    if (check_enum_bit(weapon_flags, WeaponFlag::TwoHands))
         strcat(buf, " two-handed");
-    if (weapon_flags & WEAPON_POISONED)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Poisoned))
         strcat(buf, " poisoned");
-    if (weapon_flags & WEAPON_PLAGUED)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Plagued))
         strcat(buf, " death");
-    if (weapon_flags & WEAPON_ACID)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Acid))
         strcat(buf, " acid");
-    if (weapon_flags & WEAPON_LIGHTNING)
+    if (check_enum_bit(weapon_flags, WeaponFlag::Lightning))
         strcat(buf, " lightning");
 
     return (buf[0] != '\0') ? buf + 1 : "none";

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -696,12 +696,12 @@ void spell_acid_wash(int sn, int level, Char *ch, void *vo) {
         return;
     }
 
-    if (check_bit(obj->value[4], WEAPON_LIGHTNING)) {
+    if (check_enum_bit(obj->value[4], WeaponFlag::Lightning)) {
         ch->send_line("Acid and lightning don't mix.");
         return;
     }
     obj->value[3] = AttackTableIndexAcidWash;
-    set_bit(obj->value[4], WEAPON_ACID);
+    set_enum_bit(obj->value[4], WeaponFlag::Acid);
     ch->send_to("With a mighty scream you draw acid from the earth.\n\rYou wash your weapon in the acid pool.\n\r");
 }
 
@@ -2005,7 +2005,7 @@ void spell_vorpal(int sn, int level, Char *ch, void *vo) {
     }
 
     ch->gold -= (mana * 100);
-    set_bit(obj->value[4], WEAPON_VORPAL);
+    set_enum_bit(obj->value[4], WeaponFlag::Vorpal);
     ch->send_line("You create a flaw in the universe and place it on your blade!");
 }
 
@@ -2028,9 +2028,8 @@ void spell_venom(int sn, int level, Char *ch, void *vo) {
         ch->send_line("You can't afford to!");
         return;
     }
-
     ch->gold -= (mana * 100);
-    set_bit(obj->value[4], WEAPON_POISONED);
+    set_enum_bit(obj->value[4], WeaponFlag::Poisoned);
     ch->send_line("You coat the blade in poison!");
 }
 
@@ -2053,9 +2052,8 @@ void spell_black_death(int sn, int level, Char *ch, void *vo) {
         ch->send_line("You can't afford to!");
         return;
     }
-
     ch->gold -= (mana * 100);
-    set_bit(obj->value[4], WEAPON_PLAGUED);
+    set_enum_bit(obj->value[4], WeaponFlag::Plagued);
     ch->send_line("Your use your cunning and skill to plague the weapon!");
 }
 
@@ -2100,7 +2098,7 @@ void spell_vampire(int sn, int level, Char *ch, void *vo) {
     }
 
     if (ch->is_immortal()) {
-        set_bit(obj->value[4], WEAPON_VAMPIRIC);
+        set_enum_bit(obj->value[4], WeaponFlag::Vampiric);
         ch->send_line("You suck the life force from the weapon leaving it hungry for blood.");
     }
 }
@@ -2119,7 +2117,7 @@ void spell_tame_lightning(int sn, int level, Char *ch, void *vo) {
         return;
     }
 
-    if (check_bit(obj->value[4], WEAPON_ACID)) {
+    if (check_enum_bit(obj->value[4], WeaponFlag::Acid)) {
         ch->send_line("Acid and lightning do not mix.");
         return;
     }
@@ -2132,7 +2130,7 @@ void spell_tame_lightning(int sn, int level, Char *ch, void *vo) {
 
     ch->gold -= (mana * 100);
     obj->value[3] = AttackTableIndexTameLightning;
-    set_bit(obj->value[4], WEAPON_LIGHTNING);
+    set_enum_bit(obj->value[4], WeaponFlag::Lightning);
     ch->send_to("You summon a MASSIVE storm.\n\rHolding your weapon aloft you call lightning down from the sky. "
                 "\n\rThe lightning swirls around it - you have |YTAMED|w the |YLIGHTNING|w.\n\r");
 }
@@ -2298,7 +2296,7 @@ void spell_frenzy(int sn, int level, Char *ch, void *vo) {
     act("$n gets a wild look in $s eyes!", victim);
 
     /*  if ( (wield !=nullptr) && (wield->type == ObjectType::Weapon) &&
-          (check_bit(wield->value[4], WEAPON_FLAMING)))
+          (check_bit(wield->value[4], WeaponFlaming)))
         ch->send_line("Your great energy causes your weapon to burst into flame.");
       wield->value[3] = 29;*/
 }
@@ -2616,25 +2614,25 @@ void spell_identify(int sn, int level, Char *ch, void *vo) {
         ch->send_line("Weapon type is {}.", Weapons::name_from_integer(obj->value[0]));
         if ((obj->value[4] != 0) && (obj->type == ObjectType::Weapon)) {
             ch->send_to("Weapon flags:");
-            if (check_bit(obj->value[4], WEAPON_FLAMING))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Flaming))
                 ch->send_to(" flaming");
-            if (check_bit(obj->value[4], WEAPON_FROST))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Frost))
                 ch->send_to(" frost");
-            if (check_bit(obj->value[4], WEAPON_VAMPIRIC))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Vampiric))
                 ch->send_to(" vampiric");
-            if (check_bit(obj->value[4], WEAPON_SHARP))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Sharp))
                 ch->send_to(" sharp");
-            if (check_bit(obj->value[4], WEAPON_VORPAL))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Vorpal))
                 ch->send_to(" vorpal");
-            if (check_bit(obj->value[4], WEAPON_TWO_HANDS))
+            if (check_enum_bit(obj->value[4], WeaponFlag::TwoHands))
                 ch->send_to(" two-handed");
-            if (check_bit(obj->value[4], WEAPON_POISONED))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Poisoned))
                 ch->send_to(" poisoned");
-            if (check_bit(obj->value[4], WEAPON_PLAGUED))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Plagued))
                 ch->send_to(" death");
-            if (check_bit(obj->value[4], WEAPON_ACID))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Acid))
                 ch->send_to(" acid");
-            if (check_bit(obj->value[4], WEAPON_LIGHTNING))
+            if (check_enum_bit(obj->value[4], WeaponFlag::Lightning))
                 ch->send_to(" lightning");
             ch->send_line(".");
         }

--- a/src/world_balance.cpp
+++ b/src/world_balance.cpp
@@ -55,22 +55,22 @@ int report_object(Object *object, int boot) {
     case ObjectType::Weapon:
         /* Calculate the damage allowed and actual */
         allowedaverage = (object->level / 2) + 4;
-        if (check_bit(obj->value[4], WEAPON_TWO_HANDS) && check_bit(obj->wear_flags, ITEM_TWO_HANDS))
+        if (check_enum_bit(obj->value[4], WeaponFlag::TwoHands) && check_bit(obj->wear_flags, ITEM_TWO_HANDS))
             allowedaverage += std::max(1, (allowedaverage) / 20);
         averagedam = (obj->value[1] * obj->value[2] + obj->value[1]) / 2;
         if ((averagedam > allowedaverage) && boot) {
             objectbug("average damage too high", obj);
         }
         /* Add to worth for each weapon type */
-        if (check_bit(obj->value[4], WEAPON_FLAMING))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Flaming))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_FROST))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Frost))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_VAMPIRIC))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Vampiric))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_SHARP))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Sharp))
             worth++;
-        if (check_bit(obj->value[4], WEAPON_VORPAL))
+        if (check_enum_bit(obj->value[4], WeaponFlag::Vorpal))
             worth++;
         break;
 


### PR DESCRIPTION
…(), set_enum_bit() in all the places they are used.