### PR TITLE
Tweak gcc/g++ install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you want to build and run Xania locally, you'll need a modern Linux (Ubuntu 1
 need the following packages to build:
 
 ```bash
-$ sudo apt install git make cmake gcc g++ curl
+$ sudo apt install git make cmake gcc-10 g++-10 curl
 ```
 
 It's pretty likely you have all these already. The hope is that almost all the upstream dependencies of the code are


### PR DESCRIPTION
Via private conversation with @mattgodbolt , currently if you only install gcc/g++ you may get these errors on running `make`:

```
CMake Error at /home/jsamuels/.cache/ozy/cmake/3.21.3/cmake-3.21.3-linux-x86_64/share/cmake-3.21/Modules/CMakeDetermineCCompiler.cmake:49 (message):
  Could not find compiler set in environment variable CC:

  gcc-10.
Call Stack (most recent call first):
  CMakeLists.txt:2 (project)


CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
See also "/home/jsamuels/code/oss/mattgodbolt/xania/cmake-build-debug/CMakeFiles/CMakeOutput.log".
make: *** [Makefile:100: /home/jsamuels/code/oss/mattgodbolt/xania/cmake-build-debug/CMakeCache.txt] Error 1
```